### PR TITLE
[FEAT] Radio 컴포넌트 구현 #32

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,6 @@
     ],
 
     "no-console": ["error"],
-    "react/jsx-no-bind": ["warn"],
     "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false }]
   },
   "settings": {

--- a/src/components/atoms/IconButton/IconButton.styled.ts
+++ b/src/components/atoms/IconButton/IconButton.styled.ts
@@ -14,7 +14,7 @@ export interface IconButtonStyleProps {
 }
 
 const IconButtonInteraction = styled(InteractionOverlay)`
-  border-radius: 10000px;
+  border-radius: 50%;
 `;
 
 const commonStyles = (theme: Theme, disable?: boolean) => css`
@@ -22,7 +22,7 @@ const commonStyles = (theme: Theme, disable?: boolean) => css`
   align-items: center;
   justify-content: center;
 
-  border-radius: 10000px;
+  border-radius: 50%;
   border: none;
   background-color: transparent;
   color: ${disable ? theme.semantic.label.disable : theme.semantic.label.normal};

--- a/src/components/atoms/Radio/Radio.stories.tsx
+++ b/src/components/atoms/Radio/Radio.stories.tsx
@@ -1,0 +1,85 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useEffect, useState } from 'react';
+
+import Radio from './Radio';
+
+const meta = {
+  title: 'components/atoms/Radio',
+  component: Radio,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'radio',
+      options: ['sm', 'md'],
+    },
+    disable: {
+      control: 'boolean',
+      description: '라디오 비활성화 여부',
+      defaultValue: false,
+    },
+    isChecked: {
+      control: 'boolean',
+      description: '선택 여부',
+    },
+    interactionVariant: {
+      control: 'radio',
+      options: ['normal', 'light', 'strong'],
+    },
+    interactionColor: {
+      control: 'color',
+      description: '인터랙션 오버레이 색상',
+      defaultValue: '#171719',
+    },
+    required: {
+      control: 'boolean',
+      defaultValue: false,
+    },
+    name: {
+      control: 'text',
+      defaultValue: 'radio-group',
+    },
+    onToggle: { action: 'toggled' },
+    interactiondisable: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} satisfies Meta<typeof Radio>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 'md',
+    isChecked: false,
+    disable: false,
+    interactionVariant: 'normal',
+    interactionColor: '#171719',
+    required: false,
+    onToggle: () => {},
+    name: 'radio-default',
+  },
+  render: (args) => {
+    const [checked, setChecked] = useState(args.isChecked);
+
+    useEffect(() => {
+      setChecked(args.isChecked);
+    }, [args.isChecked]);
+
+    const handleToggle = (value: boolean) => {
+      action('toggled')(value);
+      setChecked(value);
+    };
+
+    return (
+      <Radio
+        {...args}
+        isChecked={checked}
+        onToggle={handleToggle}
+      />
+    );
+  },
+};

--- a/src/components/atoms/Radio/Radio.styled.ts
+++ b/src/components/atoms/Radio/Radio.styled.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { SerializedStyles, css } from '@emotion/react';
 import styled from '@emotion/styled';
 

--- a/src/components/atoms/Radio/Radio.styled.ts
+++ b/src/components/atoms/Radio/Radio.styled.ts
@@ -7,8 +7,8 @@ type RadioSize = 'sm' | 'md';
 
 export interface RadioStyleProps {
   size: RadioSize;
-  disable: boolean;
-  isChecked: boolean;
+  disable?: boolean;
+  isChecked?: boolean;
 }
 
 const RadioInteraction = styled(InteractionOverlay)`

--- a/src/components/atoms/Radio/Radio.styled.ts
+++ b/src/components/atoms/Radio/Radio.styled.ts
@@ -1,0 +1,79 @@
+import { SerializedStyles, css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import InteractionOverlay from '@/styles/InteractionOverlay.styled';
+
+type RadioSize = 'sm' | 'md';
+
+export interface RadioStyleProps {
+  size: RadioSize;
+  disable: boolean;
+  isChecked: boolean;
+}
+
+const RadioInteraction = styled(InteractionOverlay)`
+  border-radius: 50%;
+`;
+
+const sizeStyles: Record<RadioSize, SerializedStyles> = {
+  sm: css`
+    height: 1.8rem;
+  `,
+  md: css`
+    height: 2.2rem;
+  `,
+};
+
+const RadioContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+
+const RadioOuter = styled.div<RadioStyleProps>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ size }) => sizeStyles[size]};
+
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: 0.1rem solid
+    ${({ isChecked, theme }) => (isChecked ? theme.semantic.primary.normal : theme.semantic.line.normal)};
+  background-color: ${({ isChecked, theme }) => (isChecked ? theme.semantic.primary.normal : 'transparent')};
+
+  opacity: ${({ disable }) => (disable ? 0.4 : 1)};
+  transition: all 0.2s ease;
+`;
+
+const RadioInner = styled.div`
+  height: 50%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.semantic.static.white};
+`;
+
+const HiddenRadio = styled.input`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+`;
+
+const S = {
+  RadioInteraction,
+  RadioContainer,
+  RadioOuter,
+  RadioInner,
+  HiddenRadio,
+};
+
+export default S;

--- a/src/components/atoms/Radio/Radio.tsx
+++ b/src/components/atoms/Radio/Radio.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { InteractionStyleProps } from '@/styles/InteractionOverlay.styled';
 
 import S, { RadioStyleProps } from './Radio.styled';

--- a/src/components/atoms/Radio/Radio.tsx
+++ b/src/components/atoms/Radio/Radio.tsx
@@ -1,0 +1,57 @@
+import { InteractionStyleProps } from '@/styles/InteractionOverlay.styled';
+
+import S, { RadioStyleProps } from './Radio.styled';
+
+interface RadioProps extends RadioStyleProps, InteractionStyleProps {
+  onToggle: (checked: boolean) => void;
+  required?: boolean;
+  name?: string;
+}
+
+export default function Radio({
+  size,
+  disable,
+  isChecked,
+  onToggle,
+  required = false,
+  name,
+  interactionVariant,
+  interactionColor,
+}: RadioProps) {
+  const handleClick = () => {
+    if (!disable) {
+      onToggle(!isChecked);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onToggle(e.target.checked);
+  };
+
+  return (
+    <S.RadioInteraction
+      interactionVariant={interactionVariant}
+      interactionColor={interactionColor}
+      interactiondisable={disable}
+      tabIndex={0}
+    >
+      <S.RadioContainer onClick={handleClick}>
+        <S.HiddenRadio
+          type='radio'
+          checked={isChecked}
+          onChange={handleChange}
+          disabled={disable}
+          name={name}
+          required={required}
+        />
+        <S.RadioOuter
+          size={size}
+          disable={disable}
+          isChecked={isChecked}
+        >
+          <S.RadioInner />
+        </S.RadioOuter>
+      </S.RadioContainer>
+    </S.RadioInteraction>
+  );
+}

--- a/src/components/atoms/TextButton/TextButton.styled.ts
+++ b/src/components/atoms/TextButton/TextButton.styled.ts
@@ -18,7 +18,7 @@ const TextButtonInteraction = styled(InteractionOverlay)`
   border-radius: ${({ theme }) => theme.radius[4]};
 `;
 
-const baseButtonStyles = (theme: Theme) => css`
+const commonStyles = (theme: Theme) => css`
   display: flex;
   align-items: center;
   gap: 4px;
@@ -59,7 +59,7 @@ const sizeStyles: Record<TextButtonSize, (theme: Theme) => SerializedStyles> = {
 };
 
 const TextButton = styled.div<TextButtonStyleProps>`
-  ${({ theme }) => baseButtonStyles(theme)};
+  ${({ theme }) => commonStyles(theme)};
   ${({ theme, size }) => sizeStyles[size](theme)};
   ${({ theme, color, disable }) => colorStyles[color](theme, disable)};
 `;

--- a/src/components/atoms/TextButton/TextButton.styled.ts
+++ b/src/components/atoms/TextButton/TextButton.styled.ts
@@ -11,7 +11,7 @@ type TextButtonSize = 'sm' | 'md' | 'lg';
 export interface TextButtonStyleProps {
   color: TextButtonColor;
   size: TextButtonSize;
-  disable: boolean;
+  disable?: boolean;
 }
 
 const TextButtonInteraction = styled(InteractionOverlay)`


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #32 

## 📋 작업 내용

- Radio 컴포넌트 구현
- TextButton과 IconButton에 각각 리팩토링하면 좋을 만한 부분들이 조금씩 있어서, 별도로 이슈를 만들기엔 변경 사항이 작다고 판단해 이번 PR에 함께 반영했습니다.
- eslint jsx-no-bind 옵션 제거
  jsx-no-bind 옵션이 화살표 함수 사용을 제한해서 useCallback을 무조건 사용해야 하는 상황이었는데, 모든 경우에 꼭 필요하진 않다고 판단해 해당 옵션을 비활성화했습니다.

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
