### PR TITLE
[FEAT] 디자인 팀 피드백 반영 #39

### DIFF
--- a/src/components/atoms/IconButton/IconButton.stories.tsx
+++ b/src/components/atoms/IconButton/IconButton.stories.tsx
@@ -21,11 +21,6 @@ const meta = {
       control: 'radio',
       options: ['normal', 'light', 'strong'],
     },
-    interactionColor: {
-      control: 'color',
-      description: '인터랙션 오버레이의 색상입니다.',
-      defaultValue: 'rgba(55, 56, 60, 0.61)',
-    },
     disable: {
       control: 'boolean',
       description: '버튼 비활성화 여부',
@@ -37,6 +32,11 @@ const meta = {
       defaultValue: false,
     },
     onClick: { action: 'clicked' },
+    interactionColor: {
+      table: {
+        disable: true,
+      },
+    },
     interactiondisable: {
       table: {
         disable: true,
@@ -53,7 +53,6 @@ export const Normal: Story = {
     variant: 'normal',
     size: '40px',
     interactionVariant: 'normal',
-    interactionColor: 'rgba(55, 56, 60, 0.61)',
     disable: false,
     pushBadge: false,
     children: <Blank />,
@@ -66,7 +65,6 @@ export const Outlined: Story = {
     variant: 'outlined',
     size: '40px',
     interactionVariant: 'light',
-    interactionColor: 'rgba(55, 56, 60, 0.61)',
     disable: false,
     pushBadge: false,
     children: <Blank />,
@@ -79,7 +77,6 @@ export const Solid: Story = {
     variant: 'solid',
     size: '40px',
     interactionVariant: 'strong',
-    interactionColor: 'rgba(55, 56, 60, 0.61)',
     disable: false,
     pushBadge: false,
     children: <Blank />,
@@ -92,7 +89,6 @@ export const Background: Story = {
     variant: 'background',
     size: '40px',
     interactionVariant: 'normal',
-    interactionColor: 'rgba(55, 56, 60, 0.61)',
     disable: false,
     pushBadge: false,
     children: <Blank />,

--- a/src/components/atoms/IconButton/IconButton.stories.tsx
+++ b/src/components/atoms/IconButton/IconButton.stories.tsx
@@ -34,12 +34,12 @@ const meta = {
     onClick: { action: 'clicked' },
     interactionColor: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
     interactionDisabled: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
   },

--- a/src/components/atoms/IconButton/IconButton.stories.tsx
+++ b/src/components/atoms/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
       control: 'radio',
       options: ['normal', 'light', 'strong'],
     },
-    disable: {
+    isDisabled: {
       control: 'boolean',
       description: '버튼 비활성화 여부',
       defaultValue: false,
@@ -34,12 +34,12 @@ const meta = {
     onClick: { action: 'clicked' },
     interactionColor: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
-    interactiondisable: {
+    interactionDisabled: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
   },
@@ -53,7 +53,7 @@ export const Normal: Story = {
     variant: 'normal',
     size: '40px',
     interactionVariant: 'normal',
-    disable: false,
+    isDisabled: false,
     pushBadge: false,
     children: <Blank />,
     onClick: action('clicked'),
@@ -65,7 +65,7 @@ export const Outlined: Story = {
     variant: 'outlined',
     size: '40px',
     interactionVariant: 'light',
-    disable: false,
+    isDisabled: false,
     pushBadge: false,
     children: <Blank />,
     onClick: action('clicked'),
@@ -77,7 +77,7 @@ export const Solid: Story = {
     variant: 'solid',
     size: '40px',
     interactionVariant: 'strong',
-    disable: false,
+    isDisabled: false,
     pushBadge: false,
     children: <Blank />,
     onClick: action('clicked'),
@@ -89,7 +89,7 @@ export const Background: Story = {
     variant: 'background',
     size: '40px',
     interactionVariant: 'normal',
-    disable: false,
+    isDisabled: false,
     pushBadge: false,
     children: <Blank />,
     onClick: action('clicked'),

--- a/src/components/atoms/IconButton/IconButton.styled.ts
+++ b/src/components/atoms/IconButton/IconButton.styled.ts
@@ -23,10 +23,10 @@ const commonStyles = (theme: Theme, disable?: boolean) => css`
   justify-content: center;
 
   border-radius: 50%;
-  border: none;
+  border: 1px solid transparent;
   background-color: transparent;
   color: ${disable ? theme.semantic.label.disable : theme.semantic.label.normal};
-  padding: 0.8rem;
+  padding: 0.7rem;
 
   &:hover {
     cursor: pointer;
@@ -47,16 +47,17 @@ const variantStyles: {
 } = {
   normal: () => css``,
   background: (theme: Theme) => css`
-    padding: 0.4rem;
+    padding: 0.5rem;
     background-color: ${theme.semantic.fill.normal};
+    border-color: ${theme.semantic.fill.normal};
   `,
   outlined: (theme: Theme) => css`
-    padding: 0.7rem;
-    border: 1px solid ${theme.semantic.line.normal};
+    border-color: ${theme.semantic.line.normal};
   `,
   solid: (theme: Theme, disable?: boolean) => css`
     background-color: ${disable ? theme.semantic.interaction.disable : theme.semantic.primary.normal};
     color: ${disable ? theme.semantic.label.disable : theme.semantic.static.white};
+    border-color: ${disable ? theme.semantic.interaction.disable : theme.semantic.primary.normal};
   `,
 };
 

--- a/src/components/atoms/IconButton/IconButton.styled.ts
+++ b/src/components/atoms/IconButton/IconButton.styled.ts
@@ -10,14 +10,13 @@ type IconButtonVariant = 'normal' | 'background' | 'outlined' | 'solid';
 export interface IconButtonStyleProps {
   size: string;
   variant: IconButtonVariant;
-  disable?: boolean;
 }
 
 const IconButtonInteraction = styled(InteractionOverlay)`
   border-radius: 50%;
 `;
 
-const commonStyles = (theme: Theme, disable?: boolean) => css`
+const commonStyles = (theme: Theme) => css`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -25,7 +24,7 @@ const commonStyles = (theme: Theme, disable?: boolean) => css`
   border-radius: 50%;
   border: 1px solid transparent;
   background-color: transparent;
-  color: ${disable ? theme.semantic.label.disable : theme.semantic.label.normal};
+  color: ${theme.semantic.label.normal};
   padding: 0.7rem;
 
   &:hover {
@@ -35,6 +34,11 @@ const commonStyles = (theme: Theme, disable?: boolean) => css`
   &:focus {
     outline: none;
   }
+
+  &:disabled {
+    color: ${theme.semantic.label.disable};
+    cursor: default;
+  }
 `;
 
 const sizeStyles = (size: string) => css`
@@ -43,28 +47,37 @@ const sizeStyles = (size: string) => css`
 `;
 
 const variantStyles: {
-  [key in IconButtonVariant]: (theme: Theme, disable?: boolean) => SerializedStyles;
+  [key in IconButtonVariant]: (theme: Theme) => SerializedStyles;
 } = {
   normal: () => css``,
+
   background: (theme: Theme) => css`
     padding: 0.5rem;
     background-color: ${theme.semantic.fill.normal};
     border-color: ${theme.semantic.fill.normal};
   `,
+
   outlined: (theme: Theme) => css`
     border-color: ${theme.semantic.line.normal};
   `,
-  solid: (theme: Theme, disable?: boolean) => css`
-    background-color: ${disable ? theme.semantic.interaction.disable : theme.semantic.primary.normal};
-    color: ${disable ? theme.semantic.label.disable : theme.semantic.static.white};
-    border-color: ${disable ? theme.semantic.interaction.disable : theme.semantic.primary.normal};
+
+  solid: (theme: Theme) => css`
+    background-color: ${theme.semantic.primary.normal};
+    color: ${theme.semantic.static.white};
+    border-color: ${theme.semantic.primary.normal};
+
+    &:disabled {
+      background-color: ${theme.semantic.interaction.disable};
+      color: ${theme.semantic.label.disable};
+      border-color: ${theme.semantic.interaction.disable};
+    }
   `,
 };
 
 const IconButton = styled.button<IconButtonStyleProps>`
-  ${({ theme, disable }) => commonStyles(theme, disable)}
-  ${({ size }) => sizeStyles(size)}
-  ${({ variant, theme, disable }) => variantStyles[variant](theme, disable)}
+  ${({ theme }) => commonStyles(theme)};
+  ${({ size }) => sizeStyles(size)};
+  ${({ variant, theme }) => variantStyles[variant](theme)};
 `;
 
 const Container = styled.div`

--- a/src/components/atoms/IconButton/IconButton.styled.ts
+++ b/src/components/atoms/IconButton/IconButton.styled.ts
@@ -74,12 +74,12 @@ const Container = styled.div`
 
 const PushBadge = styled.div`
   position: absolute;
-  top: 8%;
-  right: 8%;
+  top: 12%;
+  right: 12%;
 
   width: 0.4rem;
   height: 0.4rem;
-  border-radius: 0.2rem;
+  border-radius: 50%;
   background-color: ${({ theme }) => theme.semantic.primary.normal};
 `;
 

--- a/src/components/atoms/IconButton/IconButton.tsx
+++ b/src/components/atoms/IconButton/IconButton.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTheme } from '@emotion/react';
+
 import { InteractionStyleProps } from '@/styles/InteractionOverlay.styled';
 
 import S, { IconButtonStyleProps } from './IconButton.styled';
@@ -15,16 +17,17 @@ export default function IconButton({
   size,
   disable,
   interactionVariant,
-  interactionColor,
   pushBadge,
   onClick,
   children,
 }: IconButtonProps) {
+  const theme = useTheme();
+
   return (
     <S.Container>
       <S.IconButtonInteraction
         interactionVariant={interactionVariant}
-        interactionColor={interactionColor}
+        interactionColor={theme.semantic.label.alternative}
         interactiondisable={disable}
         tabIndex={0}
       >

--- a/src/components/atoms/IconButton/IconButton.tsx
+++ b/src/components/atoms/IconButton/IconButton.tsx
@@ -8,6 +8,7 @@ import S, { IconButtonStyleProps } from './IconButton.styled';
 
 interface IconButtonProps extends IconButtonStyleProps, InteractionStyleProps {
   pushBadge?: boolean;
+  isDisabled?: boolean;
   onClick?: () => void;
   children: React.ReactNode;
 }
@@ -15,7 +16,7 @@ interface IconButtonProps extends IconButtonStyleProps, InteractionStyleProps {
 export default function IconButton({
   variant,
   size,
-  disable,
+  isDisabled,
   interactionVariant,
   pushBadge,
   onClick,
@@ -28,13 +29,13 @@ export default function IconButton({
       <S.IconButtonInteraction
         interactionVariant={interactionVariant}
         interactionColor={theme.semantic.label.alternative}
-        interactiondisable={disable}
+        interactionDisabled={isDisabled}
         tabIndex={0}
       >
         <S.IconButton
           size={size}
           variant={variant}
-          disable={disable}
+          disabled={isDisabled}
           onClick={onClick}
         >
           {children}

--- a/src/components/atoms/Radio/Radio.stories.tsx
+++ b/src/components/atoms/Radio/Radio.stories.tsx
@@ -37,12 +37,12 @@ const meta = {
     onToggle: { action: 'toggled' },
     interactionColor: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
     interactionDisabled: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
   },

--- a/src/components/atoms/Radio/Radio.stories.tsx
+++ b/src/components/atoms/Radio/Radio.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
       control: 'radio',
       options: ['sm', 'md'],
     },
-    disable: {
+    isDisabled: {
       control: 'boolean',
       description: '라디오 비활성화 여부',
       defaultValue: false,
@@ -37,12 +37,12 @@ const meta = {
     onToggle: { action: 'toggled' },
     interactionColor: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
-    interactiondisable: {
+    interactionDisabled: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
   },
@@ -55,7 +55,7 @@ export const Default: Story = {
   args: {
     size: 'md',
     isChecked: false,
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'normal',
     required: false,
     onToggle: () => {},

--- a/src/components/atoms/Radio/Radio.stories.tsx
+++ b/src/components/atoms/Radio/Radio.stories.tsx
@@ -26,11 +26,6 @@ const meta = {
       control: 'radio',
       options: ['normal', 'light', 'strong'],
     },
-    interactionColor: {
-      control: 'color',
-      description: '인터랙션 오버레이 색상',
-      defaultValue: '#171719',
-    },
     required: {
       control: 'boolean',
       defaultValue: false,
@@ -40,6 +35,11 @@ const meta = {
       defaultValue: 'radio-group',
     },
     onToggle: { action: 'toggled' },
+    interactionColor: {
+      table: {
+        disable: true,
+      },
+    },
     interactiondisable: {
       table: {
         disable: true,
@@ -57,7 +57,6 @@ export const Default: Story = {
     isChecked: false,
     disable: false,
     interactionVariant: 'normal',
-    interactionColor: '#171719',
     required: false,
     onToggle: () => {},
     name: 'radio-default',

--- a/src/components/atoms/Radio/Radio.styled.ts
+++ b/src/components/atoms/Radio/Radio.styled.ts
@@ -9,7 +9,7 @@ type RadioSize = 'sm' | 'md';
 
 export interface RadioStyleProps {
   size: RadioSize;
-  disable?: boolean;
+  isDisabled?: boolean;
   isChecked?: boolean;
 }
 
@@ -26,11 +26,12 @@ const sizeStyles: Record<RadioSize, SerializedStyles> = {
   `,
 };
 
-const RadioContainer = styled.div`
+const RadioContainer = styled.div<{ isDisabled?: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+
+  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
 `;
 
 const RadioOuter = styled.div<RadioStyleProps>`
@@ -46,7 +47,7 @@ const RadioOuter = styled.div<RadioStyleProps>`
     ${({ isChecked, theme }) => (isChecked ? theme.semantic.primary.normal : theme.semantic.line.normal)};
   background-color: ${({ isChecked, theme }) => (isChecked ? theme.semantic.primary.normal : 'transparent')};
 
-  opacity: ${({ disable }) => (disable ? 0.4 : 1)};
+  opacity: ${({ isDisabled }) => (isDisabled ? 0.4 : 1)};
   transition: all 0.2s ease;
 `;
 

--- a/src/components/atoms/Radio/Radio.tsx
+++ b/src/components/atoms/Radio/Radio.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTheme } from '@emotion/react';
+
 import { InteractionStyleProps } from '@/styles/InteractionOverlay.styled';
 
 import S, { RadioStyleProps } from './Radio.styled';
@@ -18,8 +20,9 @@ export default function Radio({
   required = false,
   name,
   interactionVariant,
-  interactionColor,
 }: RadioProps) {
+  const theme = useTheme();
+
   const handleClick = () => {
     if (!disable) {
       onToggle(!isChecked);
@@ -33,7 +36,7 @@ export default function Radio({
   return (
     <S.RadioInteraction
       interactionVariant={interactionVariant}
-      interactionColor={interactionColor}
+      interactionColor={theme.semantic.label.normal}
       interactiondisable={disable}
       tabIndex={0}
     >

--- a/src/components/atoms/Radio/Radio.tsx
+++ b/src/components/atoms/Radio/Radio.tsx
@@ -14,7 +14,7 @@ interface RadioProps extends RadioStyleProps, InteractionStyleProps {
 
 export default function Radio({
   size,
-  disable,
+  isDisabled,
   isChecked,
   onToggle,
   required = false,
@@ -24,7 +24,7 @@ export default function Radio({
   const theme = useTheme();
 
   const handleClick = () => {
-    if (!disable) {
+    if (!isDisabled) {
       onToggle(!isChecked);
     }
   };
@@ -37,21 +37,24 @@ export default function Radio({
     <S.RadioInteraction
       interactionVariant={interactionVariant}
       interactionColor={theme.semantic.label.normal}
-      interactiondisable={disable}
+      interactionDisabled={isDisabled}
       tabIndex={0}
     >
-      <S.RadioContainer onClick={handleClick}>
+      <S.RadioContainer
+        isDisabled={isDisabled}
+        onClick={handleClick}
+      >
         <S.HiddenRadio
           type='radio'
           checked={isChecked}
           onChange={handleChange}
-          disabled={disable}
+          disabled={isDisabled}
           name={name}
           required={required}
         />
         <S.RadioOuter
           size={size}
-          disable={disable}
+          isDisabled={isDisabled}
           isChecked={isChecked}
         >
           <S.RadioInner />

--- a/src/components/atoms/Switch/Switch.stories.tsx
+++ b/src/components/atoms/Switch/Switch.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
       control: 'boolean',
       description: '활성 상태',
     },
-    disable: {
+    isDisabled: {
       control: 'boolean',
       description: '비활성화 상태',
     },
@@ -32,7 +32,7 @@ export const Default: Story = {
   args: {
     size: 'md',
     isActive: false,
-    disable: false,
+    isDisabled: false,
     onChange: () => {},
   },
   render: (args) => {
@@ -43,7 +43,7 @@ export const Default: Story = {
     }, [args.isActive]);
 
     const handleChange = () => {
-      if (!args.disable) {
+      if (!args.isDisabled) {
         const next = !active;
         action('toggled')(next);
         setActive(next);

--- a/src/components/atoms/Switch/Switch.styled.ts
+++ b/src/components/atoms/Switch/Switch.styled.ts
@@ -8,7 +8,7 @@ type SwitchSize = 'sm' | 'md';
 export interface SwitchStyleProps {
   size: SwitchSize;
   isActive?: boolean;
-  disable?: boolean;
+  isDisabled?: boolean;
 }
 
 const knobTranslateX = {
@@ -29,16 +29,18 @@ const sizeStyles: Record<SwitchSize, SerializedStyles> = {
 
 const Switch = styled.div<SwitchStyleProps>`
   ${({ size }) => sizeStyles[size]};
+
   display: flex;
   align-items: center;
+
   padding: 0.4rem;
   border-radius: 100rem;
-  cursor: pointer;
-  transition: background-color 0.3s;
-
   background-color: ${({ isActive, theme }) => (isActive ? theme.semantic.primary.normal : theme.semantic.fill.strong)};
 
-  opacity: ${({ disable }) => (disable ? 0.43 : 1)};
+  transition: background-color 0.3s;
+  opacity: ${({ isDisabled }) => (isDisabled ? 0.43 : 1)};
+
+  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
 `;
 
 const Knob = styled.div<{ isActive?: boolean; size: SwitchSize }>`

--- a/src/components/atoms/Switch/Switch.tsx
+++ b/src/components/atoms/Switch/Switch.tsx
@@ -6,12 +6,12 @@ interface SwitchProps extends SwitchStyleProps {
   onChange: () => void;
 }
 
-export default function Switch({ size, isActive, disable, onChange }: SwitchProps) {
+export default function Switch({ size, isActive, isDisabled, onChange }: SwitchProps) {
   return (
     <S.Switch
       size={size}
       isActive={isActive}
-      disable={disable}
+      isDisabled={isDisabled}
       onClick={onChange}
     >
       <S.Knob

--- a/src/components/atoms/TextButton/TextButton.stories.tsx
+++ b/src/components/atoms/TextButton/TextButton.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'fillContainer'],
     },
     isDisabled: {
       control: 'boolean',
@@ -30,22 +30,22 @@ const meta = {
     onClick: { action: 'clicked' },
     interactionColor: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
     interactionDisabled: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
     iconLeft: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
     iconRight: {
       table: {
-        isDisabled: true,
+        disable: true,
       },
     },
   },

--- a/src/components/atoms/TextButton/TextButton.stories.tsx
+++ b/src/components/atoms/TextButton/TextButton.stories.tsx
@@ -18,7 +18,7 @@ const meta = {
       control: 'radio',
       options: ['sm', 'md', 'lg'],
     },
-    disable: {
+    isDisabled: {
       control: 'boolean',
       description: '버튼 비활성화 여부',
       defaultValue: false,
@@ -30,22 +30,22 @@ const meta = {
     onClick: { action: 'clicked' },
     interactionColor: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
-    interactiondisable: {
+    interactionDisabled: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
     iconLeft: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
     iconRight: {
       table: {
-        disable: true,
+        isDisabled: true,
       },
     },
   },
@@ -59,7 +59,7 @@ export const NoIcon: Story = {
     label: 'Label only',
     color: 'primary',
     size: 'md',
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
@@ -71,7 +71,7 @@ export const LeftIconOnly: Story = {
     iconLeft: <Blank />,
     color: 'primary',
     size: 'md',
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
@@ -83,7 +83,7 @@ export const RightIconOnly: Story = {
     iconRight: <Blank />,
     color: 'primary',
     size: 'md',
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
@@ -96,7 +96,7 @@ export const Primary: Story = {
     iconRight: <Blank />,
     color: 'primary',
     size: 'md',
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
@@ -109,7 +109,7 @@ export const Assistive: Story = {
     iconRight: <Blank />,
     color: 'assistive',
     size: 'md',
-    disable: false,
+    isDisabled: false,
     interactionVariant: 'light',
     onClick: action('clicked'),
   },

--- a/src/components/atoms/TextButton/TextButton.stories.tsx
+++ b/src/components/atoms/TextButton/TextButton.stories.tsx
@@ -27,12 +27,12 @@ const meta = {
       control: 'radio',
       options: ['normal', 'light', 'strong'],
     },
-    interactionColor: {
-      control: 'color',
-      description: '인터랙션 오버레이 색상',
-      defaultValue: 'rgba(55, 56, 60, 0.61)',
-    },
     onClick: { action: 'clicked' },
+    interactionColor: {
+      table: {
+        disable: true,
+      },
+    },
     interactiondisable: {
       table: {
         disable: true,
@@ -61,7 +61,6 @@ export const NoIcon: Story = {
     size: 'md',
     disable: false,
     interactionVariant: 'normal',
-    interactionColor: '#3067C1',
     onClick: action('clicked'),
   },
 };
@@ -74,7 +73,6 @@ export const LeftIconOnly: Story = {
     size: 'md',
     disable: false,
     interactionVariant: 'normal',
-    interactionColor: '#3067C1',
     onClick: action('clicked'),
   },
 };
@@ -87,7 +85,6 @@ export const RightIconOnly: Story = {
     size: 'md',
     disable: false,
     interactionVariant: 'normal',
-    interactionColor: '#3067C1',
     onClick: action('clicked'),
   },
 };
@@ -101,7 +98,6 @@ export const Primary: Story = {
     size: 'md',
     disable: false,
     interactionVariant: 'normal',
-    interactionColor: '#3067C1',
     onClick: action('clicked'),
   },
 };
@@ -115,7 +111,6 @@ export const Assistive: Story = {
     size: 'md',
     disable: false,
     interactionVariant: 'light',
-    interactionColor: 'rgba(55, 56, 60, 0.61)',
     onClick: action('clicked'),
   },
 };

--- a/src/components/atoms/TextButton/TextButton.styled.ts
+++ b/src/components/atoms/TextButton/TextButton.styled.ts
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import InteractionOverlay from '@/styles/InteractionOverlay.styled';
 
 type TextButtonColor = 'primary' | 'assistive';
-type TextButtonSize = 'sm' | 'md' | 'lg';
+type TextButtonSize = 'sm' | 'md' | 'lg' | 'fillContainer';
 
 export interface TextButtonStyleProps {
   color: TextButtonColor;
@@ -20,6 +20,7 @@ const TextButtonInteraction = styled(InteractionOverlay)`
 const commonStyles = (theme: Theme) => css`
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
 
   border: none;
@@ -67,6 +68,10 @@ const sizeStyles: Record<TextButtonSize, (theme: Theme) => SerializedStyles> = {
   `,
   lg: (theme) => css`
     ${theme.typography.body1.semibold};
+  `,
+  fillContainer: (theme) => css`
+    ${theme.typography.body1.semibold};
+    width: 100%;
   `,
 };
 

--- a/src/components/atoms/TextButton/TextButton.styled.ts
+++ b/src/components/atoms/TextButton/TextButton.styled.ts
@@ -11,7 +11,6 @@ type TextButtonSize = 'sm' | 'md' | 'lg';
 export interface TextButtonStyleProps {
   color: TextButtonColor;
   size: TextButtonSize;
-  disable?: boolean;
 }
 
 const TextButtonInteraction = styled(InteractionOverlay)`
@@ -35,14 +34,27 @@ const commonStyles = (theme: Theme) => css`
   &:focus {
     outline: none;
   }
+
+  &:disabled {
+    cursor: default;
+    pointer-events: none;
+  }
 `;
 
-const colorStyles: Record<TextButtonColor, (theme: Theme, disable?: boolean) => SerializedStyles> = {
-  primary: (theme, disable) => css`
-    color: ${disable ? theme.semantic.label.assistive : theme.semantic.primary.normal};
+const colorStyles: Record<TextButtonColor, (theme: Theme) => SerializedStyles> = {
+  primary: (theme) => css`
+    color: ${theme.semantic.primary.normal};
+
+    &:disabled {
+      color: ${theme.semantic.label.assistive};
+    }
   `,
-  assistive: (theme, disable) => css`
-    color: ${disable ? theme.semantic.label.assistive : theme.semantic.label.alternative};
+  assistive: (theme) => css`
+    color: ${theme.semantic.label.alternative};
+
+    &:disabled {
+      color: ${theme.semantic.label.assistive};
+    }
   `,
 };
 
@@ -58,10 +70,10 @@ const sizeStyles: Record<TextButtonSize, (theme: Theme) => SerializedStyles> = {
   `,
 };
 
-const TextButton = styled.div<TextButtonStyleProps>`
+const TextButton = styled.button<TextButtonStyleProps>`
   ${({ theme }) => commonStyles(theme)};
   ${({ theme, size }) => sizeStyles[size](theme)};
-  ${({ theme, color, disable }) => colorStyles[color](theme, disable)};
+  ${({ theme, color }) => colorStyles[color](theme)};
 `;
 
 const Icon = styled.div`

--- a/src/components/atoms/TextButton/TextButton.tsx
+++ b/src/components/atoms/TextButton/TextButton.tsx
@@ -10,6 +10,7 @@ interface TextButtonProps extends TextButtonStyleProps, InteractionStyleProps {
   label: string;
   iconLeft?: React.ReactNode;
   iconRight?: React.ReactNode;
+  isDisabled?: boolean;
   onClick?: () => void;
 }
 
@@ -19,7 +20,7 @@ export default function TextButton({
   iconRight,
   color,
   size,
-  disable,
+  isDisabled,
   interactionVariant,
   onClick,
 }: TextButtonProps) {
@@ -37,14 +38,14 @@ export default function TextButton({
     <S.TextButtonInteraction
       interactionVariant={interactionVariant}
       interactionColor={interactionColor}
-      interactiondisable={disable}
+      interactionDisabled={isDisabled}
       tabIndex={0}
     >
       <S.TextButton
         size={size}
         color={color}
-        disable={disable}
-        onClick={disable ? undefined : onClick}
+        disabled={isDisabled}
+        onClick={isDisabled ? undefined : onClick}
       >
         <S.Icon>{iconLeft}</S.Icon>
         {label}

--- a/src/components/atoms/TextButton/TextButton.tsx
+++ b/src/components/atoms/TextButton/TextButton.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTheme } from '@emotion/react';
+
 import { InteractionStyleProps } from '@/styles/InteractionOverlay.styled';
 
 import S, { TextButtonStyleProps } from './TextButton.styled';
@@ -19,9 +21,18 @@ export default function TextButton({
   size,
   disable,
   interactionVariant,
-  interactionColor,
   onClick,
 }: TextButtonProps) {
+  const theme = useTheme();
+
+  let interactionColor;
+
+  if (color === 'primary') {
+    interactionColor = theme.semantic.primary.normal;
+  } else if (color === 'assistive') {
+    interactionColor = theme.semantic.label.alternative;
+  }
+
   return (
     <S.TextButtonInteraction
       interactionVariant={interactionVariant}

--- a/src/styles/InteractionOverlay.styled.ts
+++ b/src/styles/InteractionOverlay.styled.ts
@@ -8,7 +8,7 @@ export type InteractionVariant = 'normal' | 'light' | 'strong';
 export interface InteractionStyleProps {
   interactionVariant: InteractionVariant;
   interactionColor?: string;
-  interactiondisable?: boolean;
+  interactionDisabled?: boolean;
 }
 
 const commonStyles = (theme: Theme, interactionColor?: string) => css`
@@ -73,8 +73,8 @@ const variantStyles = {
 
 const InteractionOverlay = styled.div<InteractionStyleProps>`
   ${({ theme, interactionColor }) => commonStyles(theme, interactionColor)}
-  ${({ interactionVariant, theme, interactiondisable }) =>
-    !interactiondisable && variantStyles[interactionVariant](theme)}
+  ${({ interactionVariant, theme, interactionDisabled }) =>
+    !interactionDisabled && variantStyles[interactionVariant](theme)}
 `;
 
 export default InteractionOverlay;


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #39 

## 📋 작업 내용

- IconButton에서 background의 패딩이 디자인과 달라 수정하였습니다

- 컴포넌트 별 interactionColor 조건 처리를 추가하여 interactionColor 고정으로 변경

- disable 명칭을 isDisabled로 변경
  디자인 시스템 전반에서 button 등 기본적으로 disabled 속성을 제공하는 컴포넌트의 경우, CSS에서는 &:disabled를 사용하는 방식이 직관적이고 일관성이 있다고 판단했습니다.
  
  이에 따라 props 네이밍도 disable보다는 불리언 의미가 명확하게 드러나는 isDisabled로 통일하는 것이 가독성과 의도를 전달하는 데 더 적절하다고 생각되어 변경하였습니다.
  
  관련해서 다른 의견 있으시면 편하게 공유해 주세요!

- disable 일때 커서 디폴트로 변경

- TextButton에 fillContainer 사이즈 추가

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
