### PR TITLE
[FEAT] AvatarPerson 컴포넌트 구현 #37

### DIFF
--- a/src/components/atoms/AvatarPerson/AvatarPerson.stories.tsx
+++ b/src/components/atoms/AvatarPerson/AvatarPerson.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DEFAULT_AVATAR_IMAGE } from '@/constants/image';
+
+import AvatarPerson from './AvatarPerson';
+
+const meta = {
+  title: 'components/atoms/AvatarPerson',
+  component: AvatarPerson,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'radio',
+      options: ['icon', 'image'],
+    },
+    size: {
+      control: 'radio',
+      options: ['xsm', 'sm', 'md', 'lg', 'xlg'],
+    },
+    src: {
+      control: 'text',
+      description: '이미지 URL',
+    },
+  },
+} satisfies Meta<typeof AvatarPerson>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Icon: Story = {
+  args: {
+    type: 'icon',
+    size: 'md',
+  },
+};
+
+export const Image: Story = {
+  args: {
+    type: 'image',
+    size: 'md',
+    src: DEFAULT_AVATAR_IMAGE,
+  },
+};

--- a/src/components/atoms/AvatarPerson/AvatarPerson.styled.ts
+++ b/src/components/atoms/AvatarPerson/AvatarPerson.styled.ts
@@ -1,0 +1,64 @@
+import { css, SerializedStyles } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export type AvatarPersonType = 'icon' | 'image';
+export type AvatarPersonSize = 'xsm' | 'sm' | 'md' | 'lg' | 'xlg';
+
+export interface AvatarPersonStyleProps {
+  type: AvatarPersonType;
+  size: AvatarPersonSize;
+}
+
+const sizeStyles: Record<AvatarPersonSize, SerializedStyles> = {
+  xsm: css`
+    height: 2.4rem;
+  `,
+  sm: css`
+    height: 3.6rem;
+  `,
+  md: css`
+    height: 4rem;
+  `,
+  lg: css`
+    height: 4.8rem;
+  `,
+  xlg: css`
+    height: 5.6rem;
+  `,
+};
+
+const typeStyles: Record<AvatarPersonType, SerializedStyles> = {
+  icon: css``,
+  image: css`
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border: 1px solid rgba(112, 115, 124, 0.08);
+      border-radius: 50%;
+      pointer-events: none;
+      box-sizing: border-box;
+    }
+  `,
+};
+
+const AvatarPerson = styled.div<AvatarPersonStyleProps>`
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ size }) => sizeStyles[size]};
+  ${({ type }) => typeStyles[type]};
+
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const S = {
+  AvatarPerson,
+};
+
+export default S;

--- a/src/components/atoms/AvatarPerson/AvatarPerson.tsx
+++ b/src/components/atoms/AvatarPerson/AvatarPerson.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Image from 'next/image';
+
+import { DEFAULT_AVATAR_IMAGE } from '@/constants/image';
+
+import S, { AvatarPersonStyleProps } from './AvatarPerson.styled';
+
+interface AvatarPersonProps extends AvatarPersonStyleProps {
+  src?: string;
+}
+
+export default function AvatarPerson({ type, src = DEFAULT_AVATAR_IMAGE, size }: AvatarPersonProps) {
+  return (
+    <S.AvatarPerson
+      type={type}
+      size={size}
+    >
+      <Image
+        src={src}
+        alt='avatar'
+        fill
+      />
+    </S.AvatarPerson>
+  );
+}

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_AVATAR_IMAGE = 'https://d3k85mwe6suqlp.cloudfront.net/default_image/Profile.png' as const;


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #37 

## 📋 작업 내용

- AvatarPerson 컴포넌트 구현
- 기본 아바타 이미지 상수로 정의 ( 추후 도메인 설정되면 주소 변경 )

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
