### PR TITLE
[FEAT] 기본 Modal 및 상태 관리 로직 구현 #52

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import Header from '@/components/organism/Header/Header';
 import Base from '@/components/organisms/Modal/Base/Base';
+import { modalRegistry } from '@/components/organisms/Modal/modalConfig';
 import EmotionRegistry from '@/lib/emotion/EmotionRegistry';
 import { mockingServer } from '@/lib/msw/mockingServer';
 import { MSWProvider } from '@/lib/msw/MSWProvider';
@@ -21,7 +22,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <QueryProvider>
               <Header />
               {children}
-              <Base />
+              <Base modalMap={modalRegistry} />
               <div id='modal-root' />
             </QueryProvider>
           </MSWProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Header from '@/components/organism/Header/Header';
+import Base from '@/components/organisms/Modal/Base/Base';
 import EmotionRegistry from '@/lib/emotion/EmotionRegistry';
 import { mockingServer } from '@/lib/msw/mockingServer';
 import { MSWProvider } from '@/lib/msw/MSWProvider';
@@ -20,6 +21,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <QueryProvider>
               <Header />
               {children}
+              <Base />
+              <div id='modal-root' />
             </QueryProvider>
           </MSWProvider>
         </EmotionRegistry>

--- a/src/components/molecules/Input/Input.tsx
+++ b/src/components/molecules/Input/Input.tsx
@@ -30,7 +30,6 @@ export default function Input({
   ...props
 }: InputProps) {
   const hasError = !!error || !!errorMessage;
-  const hasValue = Boolean(value);
 
   return (
     <S.Container>

--- a/src/components/organisms/Modal/Base/Base.stories.tsx
+++ b/src/components/organisms/Modal/Base/Base.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Base from './Base';
 import { createModalStore } from '@/stores/createModalStore';
 import type { ModalMap } from '@/types/modalTypes';
+
+import Base from './Base';
 
 type TestProps = {
   message: string;

--- a/src/components/organisms/Modal/Base/Base.stories.tsx
+++ b/src/components/organisms/Modal/Base/Base.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Base from './Base';
+import { createModalStore } from '@/stores/createModalStore';
+import type { ModalMap } from '@/types/modalTypes';
+
+type TestProps = {
+  message: string;
+};
+
+function TestModal({ message }: TestProps) {
+  return (
+    <div style={{ backgroundColor: 'white', padding: 24, zIndex: 1000 }}>
+      <p>{message}</p>
+    </div>
+  );
+}
+
+type AppModalProps = {
+  test: TestProps;
+};
+
+const testModalMap: ModalMap<AppModalProps> = {
+  test: {
+    Component: TestModal,
+    disableOutsideClick: false,
+  },
+};
+
+const useTestModalStore = createModalStore<AppModalProps>();
+
+const meta = {
+  title: 'components/organisms/Modal/Base',
+  component: Base,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    modalMap: testModalMap,
+    useModalStore: useTestModalStore,
+  },
+} satisfies Meta<typeof Base>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ModalTest: Story = {
+  render: (args) => {
+    const { open } = useTestModalStore();
+
+    const handleOpenModal = () => {
+      open('test', {
+        message: '이것은 버튼 클릭으로 열린 모달입니다.',
+      });
+    };
+
+    return (
+      <>
+        <div id='modal-root' />
+        <button onClick={handleOpenModal}>모달 열기</button>
+        <Base {...args} />
+      </>
+    );
+  },
+};

--- a/src/components/organisms/Modal/Base/Base.styled.ts
+++ b/src/components/organisms/Modal/Base/Base.styled.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+const ModalOverlay = styled.dialog`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1000;
+
+  border: none;
+  border-radius: 16px;
+  background: ${({ theme }) => theme.semantic.background.normal.normal};
+
+  padding: 0;
+  width: fit-content;
+  height: fit-content;
+
+  &::backdrop {
+    background-color: ${({ theme }) => theme.semantic.fill.dimmer};
+  }
+`;
+
+const S = {
+  ModalOverlay,
+};
+
+export default S;

--- a/src/components/organisms/Modal/Base/Base.tsx
+++ b/src/components/organisms/Modal/Base/Base.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import type { ModalMap } from '@/types/modalTypes';
-import ModalInstance from './ModalInstance/ModalInstance';
 import { useModalStore as defaultUseModalStore } from '@/stores/useModalStore';
+import type { ModalMap } from '@/types/modalTypes';
+
+import ModalInstance from './ModalInstance/ModalInstance';
 
 interface BaseProps<T extends ModalMap<any>> {
   modalMap: T;

--- a/src/components/organisms/Modal/Base/Base.tsx
+++ b/src/components/organisms/Modal/Base/Base.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useModalStore } from '@/stores/useModalStore';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+
+import { useModalStore } from '@/stores/useModalStore';
+
 import type { ModalRegistry } from '../modalConfig';
 import ModalInstance from './ModalInstance/ModalInstance';
 

--- a/src/components/organisms/Modal/Base/Base.tsx
+++ b/src/components/organisms/Modal/Base/Base.tsx
@@ -3,9 +3,14 @@
 import { useModalStore } from '@/stores/useModalStore';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import type { ModalRegistry } from '../modalConfig';
 import ModalInstance from './ModalInstance/ModalInstance';
 
-export default function Base() {
+interface BaseProps {
+  modalMap: ModalRegistry;
+}
+
+export default function Base({ modalMap }: BaseProps) {
   const { modals, close } = useModalStore();
   const [isMounted, setIsMounted] = useState(false);
 
@@ -33,6 +38,7 @@ export default function Base() {
           props={props}
           onClose={close}
           zIndex={1000 + index}
+          modalMap={modalMap}
         />
       ))}
     </>,

--- a/src/components/organisms/Modal/Base/Base.tsx
+++ b/src/components/organisms/Modal/Base/Base.tsx
@@ -1,54 +1,41 @@
 'use client';
 
 import { useModalStore } from '@/stores/useModalStore';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { modalComponents } from '../modalConfig';
-import S from './Base.styled';
+import ModalInstance from './ModalInstance/ModalInstance';
 
 export default function Base() {
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const { isOpen, modalType, modalProps, close } = useModalStore();
+  const { modals, close } = useModalStore();
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
+      if (e.key === 'Escape') {
+        close();
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
-
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [close]);
 
-  useEffect(() => {
-    const dialog = dialogRef.current;
-
-    if (!dialog) return;
-    if (isOpen && !dialog.open) dialog.showModal();
-    else if (!isOpen && dialog.open) dialog.close();
-  }, [isOpen]);
-
-  if (!isMounted || !isOpen || !modalType) return null;
-
-  const config = modalComponents[modalType];
-  if (!config) return null;
-
-  const { Component, disableOutsideClick } = config;
-
-  const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
-    if (!disableOutsideClick && dialogRef.current === e.target) close();
-  };
+  if (!isMounted || modals.length === 0) return null;
 
   return createPortal(
-    <S.ModalOverlay
-      ref={dialogRef}
-      onClick={handleOutsideClick}
-    >
-      <Component {...modalProps} />
-    </S.ModalOverlay>,
+    <>
+      {modals.map(({ type, props }, index) => (
+        <ModalInstance
+          key={index}
+          type={type}
+          props={props}
+          onClose={close}
+          zIndex={1000 + index}
+        />
+      ))}
+    </>,
     document.getElementById('modal-root')!,
   );
 }

--- a/src/components/organisms/Modal/Base/Base.tsx
+++ b/src/components/organisms/Modal/Base/Base.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useModalStore } from '@/stores/useModalStore';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { modalComponents } from '../modalConfig';
+import S from './Base.styled';
+
+export default function Base() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const { isOpen, modalType, modalProps, close } = useModalStore();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [close]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+
+    if (!dialog) return;
+    if (isOpen && !dialog.open) dialog.showModal();
+    else if (!isOpen && dialog.open) dialog.close();
+  }, [isOpen]);
+
+  if (!isMounted || !isOpen || !modalType) return null;
+
+  const config = modalComponents[modalType];
+  if (!config) return null;
+
+  const { Component, disableOutsideClick } = config;
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    if (!disableOutsideClick && dialogRef.current === e.target) close();
+  };
+
+  return createPortal(
+    <S.ModalOverlay
+      ref={dialogRef}
+      onClick={handleOutsideClick}
+    >
+      <Component {...modalProps} />
+    </S.ModalOverlay>,
+    document.getElementById('modal-root')!,
+  );
+}

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.styled.ts
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.styled.ts
@@ -2,7 +2,7 @@
 
 import styled from '@emotion/styled';
 
-const ModalOverlay = styled.dialog`
+const ModalOverlay = styled.dialog<{ $zIndex: number }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -11,7 +11,7 @@ const ModalOverlay = styled.dialog`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 1000;
+  z-index: ${({ $zIndex }) => $zIndex};
 
   border: none;
   border-radius: 16px;

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
@@ -1,7 +1,9 @@
-import type { ModalPropsMap, ModalType } from '@/stores/useModalStore';
 import { useEffect, useRef } from 'react';
-import type { ModalRegistry } from '../../modalConfig';
+
+import type { ModalPropsMap, ModalType } from '@/stores/useModalStore';
+
 import S from './ModalInstance.styled';
+import { ModalRegistry } from '../../modalConfig';
 
 interface ModalInstanceProps<T extends ModalType> {
   type: T;
@@ -20,7 +22,6 @@ export default function ModalInstance<T extends ModalType>({
 }: ModalInstanceProps<T>) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const config = modalMap[type];
-  if (!config) return null;
 
   const { Component, disableOutsideClick } = config;
 
@@ -33,6 +34,8 @@ export default function ModalInstance<T extends ModalType>({
       dialog.close();
     };
   }, []);
+
+  if (!config) return null;
 
   const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (!disableOutsideClick && e.target === dialogRef.current) {

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
@@ -1,0 +1,45 @@
+import type { ModalPropsMap, ModalType } from '@/stores/useModalStore';
+import { useEffect, useRef } from 'react';
+import { modalComponents } from '../../modalConfig';
+import S from './ModalInstance.styled';
+
+interface ModalInstanceProps<T extends ModalType> {
+  type: T;
+  props: ModalPropsMap[T];
+  onClose: () => void;
+  zIndex: number;
+}
+
+export default function ModalInstance<T extends ModalType>({ type, props, onClose, zIndex }: ModalInstanceProps<T>) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const config = modalComponents[type];
+  if (!config) return null;
+
+  const { Component, disableOutsideClick } = config;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+
+    return () => {
+      dialog.close();
+    };
+  }, []);
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    if (!disableOutsideClick && e.target === dialogRef.current) {
+      onClose();
+    }
+  };
+
+  return (
+    <S.ModalOverlay
+      ref={dialogRef}
+      onClick={handleOutsideClick}
+      $zIndex={zIndex}
+    >
+      <Component {...props} />
+    </S.ModalOverlay>
+  );
+}

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
@@ -1,6 +1,6 @@
 import type { ModalPropsMap, ModalType } from '@/stores/useModalStore';
 import { useEffect, useRef } from 'react';
-import { modalComponents } from '../../modalConfig';
+import type { ModalRegistry } from '../../modalConfig';
 import S from './ModalInstance.styled';
 
 interface ModalInstanceProps<T extends ModalType> {
@@ -8,11 +8,18 @@ interface ModalInstanceProps<T extends ModalType> {
   props: ModalPropsMap[T];
   onClose: () => void;
   zIndex: number;
+  modalMap: ModalRegistry;
 }
 
-export default function ModalInstance<T extends ModalType>({ type, props, onClose, zIndex }: ModalInstanceProps<T>) {
+export default function ModalInstance<T extends ModalType>({
+  type,
+  props,
+  onClose,
+  zIndex,
+  modalMap,
+}: ModalInstanceProps<T>) {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const config = modalComponents[type];
+  const config = modalMap[type];
   if (!config) return null;
 
   const { Component, disableOutsideClick } = config;

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
@@ -1,41 +1,33 @@
 import { useEffect, useRef } from 'react';
-
-import type { ModalPropsMap, ModalType } from '@/stores/useModalStore';
-
 import S from './ModalInstance.styled';
-import { ModalRegistry } from '../../modalConfig';
+import type { ModalMap } from '@/types/modalTypes';
 
-interface ModalInstanceProps<T extends ModalType> {
-  type: T;
-  props: ModalPropsMap[T];
+interface ModalInstanceProps<T extends ModalMap<any>, K extends keyof T = keyof T> {
+  type: K;
+  props: Parameters<T[K]['Component']>[0];
   onClose: () => void;
   zIndex: number;
-  modalMap: ModalRegistry;
+  modalMap: T;
 }
 
-export default function ModalInstance<T extends ModalType>({
+export default function ModalInstance<T extends ModalMap<any>, K extends keyof T>({
   type,
   props,
   onClose,
   zIndex,
   modalMap,
-}: ModalInstanceProps<T>) {
+}: ModalInstanceProps<T, K>) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const config = modalMap[type];
-
+  if (!config) return null;
   const { Component, disableOutsideClick } = config;
 
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
     dialog.showModal();
-
-    return () => {
-      dialog.close();
-    };
+    return () => dialog.close();
   }, []);
-
-  if (!config) return null;
 
   const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (!disableOutsideClick && e.target === dialogRef.current) {

--- a/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
+++ b/src/components/organisms/Modal/Base/ModalInstance/ModalInstance.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useRef } from 'react';
-import S from './ModalInstance.styled';
+
 import type { ModalMap } from '@/types/modalTypes';
+
+import S from './ModalInstance.styled';
 
 interface ModalInstanceProps<T extends ModalMap<any>, K extends keyof T = keyof T> {
   type: K;
@@ -19,8 +22,6 @@ export default function ModalInstance<T extends ModalMap<any>, K extends keyof T
 }: ModalInstanceProps<T, K>) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const config = modalMap[type];
-  if (!config) return null;
-  const { Component, disableOutsideClick } = config;
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -28,6 +29,9 @@ export default function ModalInstance<T extends ModalMap<any>, K extends keyof T
     dialog.showModal();
     return () => dialog.close();
   }, []);
+
+  if (!config) return null;
+  const { Component, disableOutsideClick } = config;
 
   const handleOutsideClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (!disableOutsideClick && e.target === dialogRef.current) {

--- a/src/components/organisms/Modal/Login/Login.tsx
+++ b/src/components/organisms/Modal/Login/Login.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export interface LoginProps {
+  redirectTo?: string;
+}
+
+export default function Login({ redirectTo }: LoginProps) {
+  return (
+    <div>
+      <h2>로그인</h2>
+      <p>로그인 후 이동할 경로: {redirectTo ?? '홈'}</p>
+    </div>
+  );
+}

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,13 +1,11 @@
+import type { ModalMap } from '@/types/modalTypes';
 import Login, { LoginProps } from './Login/Login';
 
-export interface ModalRegistry {
-  login: {
-    Component: (props: LoginProps) => React.JSX.Element;
-    disableOutsideClick?: boolean;
-  };
-}
+export type AppModalProps = {
+  login: LoginProps;
+};
 
-export const modalRegistry: ModalRegistry = {
+export const modalRegistry: ModalMap<AppModalProps> = {
   login: {
     Component: Login,
     disableOutsideClick: false,

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,4 +1,5 @@
 import type { ModalMap } from '@/types/modalTypes';
+
 import Login, { LoginProps } from './Login/Login';
 
 export type AppModalProps = {

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,0 +1,15 @@
+import Login, { LoginProps } from './Login/Login';
+
+export interface ModalComponentMap {
+  login: {
+    Component: (props: LoginProps) => React.JSX.Element;
+    disableOutsideClick?: boolean;
+  };
+}
+
+export const modalComponents: Partial<ModalComponentMap> = {
+  login: {
+    Component: Login,
+    disableOutsideClick: false,
+  },
+};

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,13 +1,13 @@
 import Login, { LoginProps } from './Login/Login';
 
-export interface ModalComponentMap {
+export interface ModalRegistry {
   login: {
     Component: (props: LoginProps) => React.JSX.Element;
     disableOutsideClick?: boolean;
   };
 }
 
-export const modalComponents: Partial<ModalComponentMap> = {
+export const modalRegistry: ModalRegistry = {
   login: {
     Component: Login,
     disableOutsideClick: false,

--- a/src/lib/query/QueryProvider.tsx
+++ b/src/lib/query/QueryProvider.tsx
@@ -9,7 +9,7 @@ function makeQueryClient() {
         throwOnError: true,
       },
       mutations: {
-        onError: (error) => {
+        onError: () => {
           // console.log(error); TODO: 에러 처리 로직 (toast 등)
         },
       },

--- a/src/stores/createModalStore.ts
+++ b/src/stores/createModalStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+export function createModalStore<T extends Record<string, unknown>>() {
+  type ModalType = keyof T;
+
+  type ModalInstance<K extends ModalType = ModalType> = {
+    type: K;
+    props: T[K];
+  };
+
+  type ModalStore = {
+    modals: ModalInstance[];
+    open: <K extends ModalType>(type: K, props: T[K]) => void;
+    close: () => void;
+    closeAll: () => void;
+  };
+
+  return create<ModalStore>((set) => ({
+    modals: [],
+    open: (type, props) =>
+      set((state) => ({
+        modals: [...state.modals, { type, props }],
+      })),
+    close: () =>
+      set((state) => ({
+        modals: state.modals.slice(0, -1),
+      })),
+    closeAll: () => set({ modals: [] }),
+  }));
+}

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,28 +1,4 @@
-import { create } from 'zustand';
+import { AppModalProps } from '@/components/organisms/Modal/modalConfig';
+import { createModalStore } from './createModalStore';
 
-import { ModalRegistry } from '@/components/organisms/Modal/modalConfig';
-
-export type ModalType = keyof ModalRegistry;
-
-export type ModalPropsMap = {
-  [K in ModalType]: Parameters<ModalRegistry[K]['Component']>[0];
-};
-
-type ModalInstance<T extends ModalType = ModalType> = {
-  type: T;
-  props: ModalPropsMap[T];
-};
-
-type ModalStore = {
-  modals: ModalInstance[];
-  open: <T extends ModalType>(type: T, props: ModalPropsMap[T]) => void;
-  close: () => void;
-  closeAll: () => void;
-};
-
-export const useModalStore = create<ModalStore>((set) => ({
-  modals: [],
-  open: (type, props) => set((state) => ({ modals: [...state.modals, { type, props }] })),
-  close: () => set((state) => ({ modals: state.modals.slice(0, -1) })),
-  closeAll: () => set(() => ({ modals: [] })),
-}));
+export const useModalStore = createModalStore<AppModalProps>();

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -3,22 +3,25 @@ import { create } from 'zustand';
 
 export type ModalType = keyof ModalComponentMap;
 
-type ModalPropsMap = {
+export type ModalPropsMap = {
   [K in ModalType]: Parameters<ModalComponentMap[K]['Component']>[0];
 };
 
+type ModalInstance<T extends ModalType = ModalType> = {
+  type: T;
+  props: ModalPropsMap[T];
+};
+
 type ModalStore = {
-  isOpen: boolean;
-  modalType: ModalType | null;
-  modalProps: ModalType extends keyof ModalPropsMap ? ModalPropsMap[ModalType] : Record<string, unknown>;
+  modals: ModalInstance[];
   open: <T extends ModalType>(type: T, props: ModalPropsMap[T]) => void;
   close: () => void;
+  closeAll: () => void;
 };
 
 export const useModalStore = create<ModalStore>((set) => ({
-  isOpen: false,
-  modalType: null,
-  modalProps: {},
-  open: (type, props) => set({ isOpen: true, modalType: type, modalProps: props }),
-  close: () => set({ isOpen: false, modalType: null, modalProps: {} }),
+  modals: [],
+  open: (type, props) => set((state) => ({ modals: [...state.modals, { type, props }] })),
+  close: () => set((state) => ({ modals: state.modals.slice(0, -1) })),
+  closeAll: () => set(() => ({ modals: [] })),
 }));

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,5 +1,6 @@
-import { ModalRegistry } from '@/components/organisms/Modal/modalConfig';
 import { create } from 'zustand';
+
+import { ModalRegistry } from '@/components/organisms/Modal/modalConfig';
 
 export type ModalType = keyof ModalRegistry;
 

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,0 +1,24 @@
+import { ModalComponentMap } from '@/components/organisms/Modal/modalConfig';
+import { create } from 'zustand';
+
+export type ModalType = keyof ModalComponentMap;
+
+type ModalPropsMap = {
+  [K in ModalType]: Parameters<ModalComponentMap[K]['Component']>[0];
+};
+
+type ModalStore = {
+  isOpen: boolean;
+  modalType: ModalType | null;
+  modalProps: ModalType extends keyof ModalPropsMap ? ModalPropsMap[ModalType] : Record<string, unknown>;
+  open: <T extends ModalType>(type: T, props: ModalPropsMap[T]) => void;
+  close: () => void;
+};
+
+export const useModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  modalType: null,
+  modalProps: {},
+  open: (type, props) => set({ isOpen: true, modalType: type, modalProps: props }),
+  close: () => set({ isOpen: false, modalType: null, modalProps: {} }),
+}));

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,4 +1,5 @@
 import { AppModalProps } from '@/components/organisms/Modal/modalConfig';
+
 import { createModalStore } from './createModalStore';
 
 export const useModalStore = createModalStore<AppModalProps>();

--- a/src/stores/useModalStore.ts
+++ b/src/stores/useModalStore.ts
@@ -1,10 +1,10 @@
-import { ModalComponentMap } from '@/components/organisms/Modal/modalConfig';
+import { ModalRegistry } from '@/components/organisms/Modal/modalConfig';
 import { create } from 'zustand';
 
-export type ModalType = keyof ModalComponentMap;
+export type ModalType = keyof ModalRegistry;
 
 export type ModalPropsMap = {
-  [K in ModalType]: Parameters<ModalComponentMap[K]['Component']>[0];
+  [K in ModalType]: Parameters<ModalRegistry[K]['Component']>[0];
 };
 
 type ModalInstance<T extends ModalType = ModalType> = {

--- a/src/types/modalTypes.ts
+++ b/src/types/modalTypes.ts
@@ -1,0 +1,8 @@
+export type ModalDefinition<P> = {
+  Component: (props: P) => React.JSX.Element;
+  disableOutsideClick?: boolean;
+};
+
+export type ModalMap<T extends Record<string, unknown>> = {
+  [K in keyof T]: ModalDefinition<T[K]>;
+};


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #52

## 📋 작업 내용

- 모달 렌더링 구조를 추상화하여 재사용 가능하게 만들고,

- 상태 관리와 UI 구현 간 결합도를 낮춰 테스트 가능성과 유연성을 확보했습니다.


### createModalStore<T>() - 제네릭 팩토리 패턴 적용

```js
export function createModalStore<T extends Record<string, unknown>>() {
  return create<ModalStore>(...) // Zustand 기반 store 생성
}
```

다양한 모달 타입을 받아 useModalStore를 생성해주는 팩토리 역할을 합니다. 어떤 모달 그룹이든 필요할 때마다 원하는 구조로 상태 관리 인스턴스를 생성할 수 있습니다.

AppModalProps, AdminModalProps, MarketingModalProps 등 모달 그룹이 여러개 생긴다면 그룹마다의 별도 store를 생성할 수 있어 역할 분리와 확장성에 유리합니다.

전역 store에 의존하지 않고, 필요한 곳에 독립적인 store를 선언해 사용할 수 있습니다.

테스트/Storybook 환경에서도 모달 상태를 격리된 형태로 주입하여 사용 가능합니다.

```js
// 사용자용 모달 상태
export const useUserModalStore = createModalStore<UserModalProps>();

// 관리자용 모달 상태
export const useAdminModalStore = createModalStore<AdminModalProps>();
```


### Base.tsx - 의존성 주입

```js
// modalConfig.ts
import type { ModalMap } from '@/types/modalTypes';
import Login, { LoginProps } from './Login/Login';

export type AppModalProps = {
  login: LoginProps;
};

export const modalRegistry: ModalMap<AppModalProps> = {
  login: {
    Component: Login,
    disableOutsideClick: false,
  },
};
```

```js
interface BaseProps<T extends ModalMap<any>> {
  modalMap: T;
  useModalStore?: () => { modals: ..., close: () => void };
}
```

```js
// RootLayout
<Base modalMap={modalRegistry} />
<div id='modal-root' />
```

Base는 내부적으로 어떤 모달이 렌더링되는지 모르고, 외부에서 modalMap과 useModalStore를 주입받아 동작합니다.

이를 통해 상태(store)와 UI 로직을 완전히 분리하고, 결합도를 낮췄습니다.

새로운 모달을 추가할 때는 modalConfig.ts만 수정하면 됩니다.

다른 모달 그룹?을 추가하더라도 Base에 새로운 modalMap과 store만 주입하면 재사용 가능합니다.

Storybook, 테스트, 특정 모듈 전용 모달 등에서 커스텀 store를 주입하여 독립적으로 활용할 수 있습니다.

```js
// A.tsx (User 모듈)
<Base modalMap={userModalMap} useModalStore={useUserModalStore} />

// B.tsx (Admin 모듈)
<Base modalMap={adminModalMap} useModalStore={useAdminModalStore} />
```

### 간단한 사용방법 정리

1. 원하는 모달 컴포넌트를 구현합니다.
```js
'use client';

export interface LoginProps {
  redirectTo?: string;
}

export default function Login({ redirectTo }: LoginProps) {
  return (
    <div>
      <h2>로그인</h2>
      <p>로그인 후 이동할 경로: {redirectTo ?? '홈'}</p>
    </div>
  );
}
```

2. modalConfig.ts에 해당 컴포넌트를 등록합니다.
```js
import type { ModalMap } from '@/types/modalTypes';
import Login, { LoginProps } from './Login/Login';

export type AppModalProps = {
  login: LoginProps;
};

export const modalRegistry: ModalMap<AppModalProps> = {
  login: {
    Component: Login,
    disableOutsideClick: false,
  },
};
```

3. useModalStore를 이용해 모달을 엽니다.
```js
'use client';

import { useModalStore } from '@/stores/useModalStore';

export default function Home() {
  const { open } = useModalStore();

  const handleClick = () => {
    open('login', { redirectTo: '/dashboard' });
  };

  return <button onClick={handleClick}>로그인 모달 열기</button>;
}
```


## 🛠️ 특이 사항

리팩토링을 진행하면서 자연스럽게 SOLID 원칙을 적용하게 되었고, 그 과정에서 많은 것을 배울 수 있었습니다.

- SRP | 하나의 모듈은 하나의 책임만 가져야 한다
Base.tsx: 모달 렌더링만 담당
ModalInstance.tsx: 단일 모달 처리
createModalStore.ts: 모달 상태 관리만 담당
modalConfig.ts: 모달 정의만 담고 있음

- OCP | 확장에는 열려 있고, 수정에는 닫혀 있어야 한다
modalMap 전략 구조 도입으로 새 모달 추가 시 Base.tsx 수정 없이 동작 
새로운 모달 그룹 추가 시 기존 코드 변경 없음

- LSP | 서브타입이 부모 타입을 대체할 수 있어야 한다 
ModalMap<T> 구조에서 각 모달 컴포넌트는 동일한 인터페이스(Component with props)를 따르므로 대체 가능

- ISP | 사용하지 않는 인터페이스에 의존하지 않아야 한다 
각 모달은 자신이 필요한 props만 정의 (LoginProps, SignupProps 등)- 공통 props 강제 없음

- DIP | 고수준 모듈은 저수준 모듈에 의존하지 않아야 한다
Base.tsx는 내부 store 구현과 모달 종류를 몰라도 동작 가능 (modalMap, useModalStore 주입)
실제 store는 외부에서 주입되어 테스트/mock 가능

일단 제가 고민했던 부분들에 대해 공유 드립니다!

다만, 이 구조가 정말 좋은 코드인지에 대해서는 아직 확신이 들지 않아 피드백을 부탁드립니다.

## ⚡️ 리뷰 요구사항 (선택)

모달 시스템을 구현하고 Storybook 테스트를 작성하는 과정에서 추상화의 중요성을 체감했습니다.. 확실히 테스트 코드 짜는게 코드 측면에서 좋은 것 같습니다

하지만.. 대부분의 로직은 추상화에 성공했지만, useModalStore 부분은 완전히 분리해내지 못해 이번 PR에는 추상화하지 않은 형태로 우선 올리게 되었습니다. (따라서 Storybook 테스트 코드도 이번 PR에는 포함되지 않았습니다.)

zustand 기반으로 구현된 다양한 예시들을 참고하며 구조를 고민해본 결과, 전체적인 설계 방향은 나쁘지 않다고 생각되는데.. 정말 useModalStore 부분만 잘 정리하면 구조적으로도 훨씬 깔끔해질 수 있을 것 같습니다..

혹시 이 부분에 대해 더 나은 방향이나 조언이 있다면 피드백 부탁드립니다!ㅠㅠ 

(해결 완료)