### PR TITLE
[FEAT] cd 설정 - Vercel 배포 시 디스코드 알림 #66

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,87 @@
+name: Deployment Notification to Discord
+
+on:
+  deployment_status:
+
+jobs:
+  notify-discord:
+    name: Notify Discord on Deployment Status
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.deployment_status.state == 'success' || github.event.deployment_status.state == 'failure') &&
+      (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+
+    steps:
+      - name: Get branch name
+        id: branch
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/"* ]]; then
+            BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          else
+            BRANCH_NAME="unknown"
+          fi
+          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          STATUS="${{ github.event.deployment_status.state }}"
+          ENVIRONMENT="${{ github.event.deployment.environment }}"
+          URL="${{ github.event.deployment_status.target_url }}"
+          BRANCH="${{ steps.branch.outputs.name }}"
+          REPO="${{ github.repository }}"
+          COMMIT="${{ github.sha }}"
+
+          # 상태에 따른 이모지 설정
+          if [ "$STATUS" == "success" ]; then
+            EMOJI="✅"
+            COLOR="3066993"  # 초록색
+          else
+            EMOJI="❌"
+            COLOR="15158332"  # 빨간색
+          fi
+
+          # Discord embed 메시지 생성
+          JSON_PAYLOAD=$(cat <<EOF
+          {
+            "embeds": [
+              {
+                "title": "$EMOJI 배포 $STATUS",
+                "color": $COLOR,
+                "fields": [
+                  {
+                    "name": "환경",
+                    "value": "$ENVIRONMENT",
+                    "inline": true
+                  },
+                  {
+                    "name": "브랜치",
+                    "value": "$BRANCH",
+                    "inline": true
+                  },
+                  {
+                    "name": "저장소",
+                    "value": "$REPO",
+                    "inline": true
+                  },
+                  {
+                    "name": "배포 URL",
+                    "value": "$URL"
+                  },
+                  {
+                    "name": "커밋",
+                    "value": "\`${COMMIT:0:7}\`",
+                    "inline": true
+                  }
+                ],
+                "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+              }
+            ]
+          }
+          EOF
+          )
+
+          curl -H "Content-Type: application/json" \
+               -d "$JSON_PAYLOAD" \
+               $DISCORD_WEBHOOK_URL


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #66 

## 📋 작업 내용

GitHub Actions를 통해 develop, master 브랜치의 배포 상태를 Discord로 알림받는 기능을 추가했습니다.

- 배포 성공 시 초록색, 실패 시 빨간색으로 구분
- 배포 환경, 브랜치명, 저장소, 배포 URL, 커밋 해시 정보 포함
- deployment_status 이벤트 발생 시 자동으로 알림 전송

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
