### PR TITLE
[FEAT] 프론트 이슈 해결 및 리팩토링 #76

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -7,7 +7,9 @@ jobs:
   notify-discord:
     name: Notify Discord on Deployment Status
     runs-on: ubuntu-latest
-    if: (github.event.deployment_status.state == 'success' || github.event.deployment_status.state == 'failure') && (github.event.deployment.environment == 'Production – cogroom-preview' || github.event.deployment.environment == 'Production – cogroom-storybook')
+    if: |
+      (github.event.deployment_status.state == 'success' || github.event.deployment_status.state == 'failure') &&
+      (github.event.deployment.environment == 'Production – cogroom-preview' || github.event.deployment.environment == 'Production – cogroom-storybook')
 
     steps:
       - name: Notify Discord
@@ -17,7 +19,6 @@ jobs:
           STATUS="${{ github.event.deployment_status.state }}"
           ENVIRONMENT="${{ github.event.deployment.environment }}"
           URL="${{ github.event.deployment_status.target_url }}"
-          BRANCH="${{ steps.branch.outputs.name }}"
           REPO="${{ github.repository }}"
           COMMIT="${{ github.sha }}"
 
@@ -28,6 +29,15 @@ jobs:
           else
             EMOJI="❌"
             COLOR="15158332"  # 빨간색
+          fi
+
+          # 커스텀 도메인 매핑
+          if [ "$ENVIRONMENT" == "Production – cogroom-preview" ]; then
+            DISPLAY_URL="https://preview.cogroom.com"
+          elif [ "$ENVIRONMENT" == "Production – cogroom-storybook" ]; then
+            DISPLAY_URL="https://story.cogroom.com"
+          else
+            DISPLAY_URL="$URL"
           fi
 
           # Discord embed 메시지 생성
@@ -50,7 +60,7 @@ jobs:
                   },
                   {
                     "name": "배포 URL",
-                    "value": "$URL"
+                    "value": "$DISPLAY_URL"
                   },
                   {
                     "name": "커밋",

--- a/src/app/daily/layout.styled.ts
+++ b/src/app/daily/layout.styled.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DailyWrapper = styled.main`
+  width: 100%;
+  height: 100%;
+`;
+
+export const Spacer = styled.div`
+  height: 20rem;
+`;

--- a/src/app/daily/layout.tsx
+++ b/src/app/daily/layout.tsx
@@ -1,4 +1,4 @@
-import * as S from './styled';
+import * as S from './layout.styled';
 
 export default function DailyLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/daily/page.styled.ts
+++ b/src/app/daily/page.styled.ts
@@ -2,17 +2,6 @@
 
 import styled from '@emotion/styled';
 
-// layout
-export const DailyWrapper = styled.main`
-  width: 100%;
-  height: 100%;
-`;
-
-export const Spacer = styled.div`
-  height: 20rem;
-`;
-
-// page
 export const DailyPageWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -7,7 +7,7 @@ import Breadcrumb from '@/components/molecules/Breadcrumb/Breadcrumb';
 import useGetDailyQuery from '@/hooks/api/daily/useGetDaily';
 import useGetStreakDaysQuery from '@/hooks/api/streak/useGetStreakDays';
 
-import * as S from './styled';
+import * as S from './page.styled';
 
 export default function Daily() {
   const { data: dailyData, isLoading } = useGetDailyQuery();

--- a/src/app/mypage/_components/MyPageBreadcrumb/MyPageBreadcrumb.tsx
+++ b/src/app/mypage/_components/MyPageBreadcrumb/MyPageBreadcrumb.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import Breadcrumb from '@/components/molecules/Breadcrumb/Breadcrumb';
+
+export default function MyPageBreadcrumb() {
+  const pathname = usePathname();
+
+  const getBreadcrumbItems = (pathname: string) => {
+    const items = [
+      { name: '홈', href: '/' },
+      { name: '마이페이지', href: '/mypage' },
+    ];
+
+    const pathMap: Record<string, string> = {
+      '/mypage/setting': '개인정보 설정',
+      '/mypage/history': '학습 및 활동 기록',
+      '/mypage/purchase': '구매 기록',
+      '/mypage/community': '커뮤니티 활동',
+      '/mypage/notification': '푸시 및 카톡 알림',
+    };
+
+    if (pathMap[pathname]) {
+      items.push({ name: pathMap[pathname], href: pathname });
+    }
+
+    return items;
+  };
+
+  return <Breadcrumb items={getBreadcrumbItems(pathname)} />;
+}

--- a/src/app/mypage/_components/Sidebar/Sidebar.styled.ts
+++ b/src/app/mypage/_components/Sidebar/Sidebar.styled.ts
@@ -2,6 +2,8 @@
 
 import styled from '@emotion/styled';
 
+import { getInteraction } from '@/styles/interaction';
+
 const Sidebar = styled.div`
   display: flex;
   flex-direction: column;
@@ -36,12 +38,19 @@ const SettingIcon = styled.button`
 const SidebarNavList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing[24]};
+  gap: ${({ theme }) => theme.spacing[16]};
 `;
 
-const Logout = styled.p`
+const Logout = styled.button`
   ${({ theme }) => theme.typography.body2.semibold};
-  color: ${({ theme }) => theme.semantic.label.normal};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+  ${({ theme }) => getInteraction('normal', theme.semantic.label.alternative)(theme)};
+
+  display: flex;
+  align-items: center;
+
+  height: 3rem;
+  border-radius: ${({ theme }) => theme.radius[4]};
 `;
 
 const S = {

--- a/src/app/mypage/_components/Sidebar/Sidebar.styled.ts
+++ b/src/app/mypage/_components/Sidebar/Sidebar.styled.ts
@@ -9,7 +9,7 @@ const Sidebar = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing[40]};
 
-  width: 27.1rem;
+  width: 20rem;
 `;
 
 const Profile = styled.div`

--- a/src/app/mypage/_components/Sidebar/Sidebar.tsx
+++ b/src/app/mypage/_components/Sidebar/Sidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { usePathname, useRouter } from 'next/navigation';
 
 import Setting from '@/assets/icons/setting.svg';

--- a/src/app/mypage/_components/Sidebar/Sidebar.tsx
+++ b/src/app/mypage/_components/Sidebar/Sidebar.tsx
@@ -38,6 +38,7 @@ export default function Sidebar() {
                 label={label}
                 href={href}
                 isActive={pathname.startsWith(href)}
+                interactionVariant='normal'
               />
             ))}
             <S.Logout>로그아웃</S.Logout>

--- a/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.styled.ts
+++ b/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.styled.ts
@@ -2,14 +2,25 @@
 
 import styled from '@emotion/styled';
 
+import { getInteraction, InteractionVariant } from '@/styles/interaction';
+
 export interface SidebarNavItemStyleProps {
   isActive: boolean;
+  interactionVariant: InteractionVariant;
 }
 
 const SidebarNavItem = styled.li<SidebarNavItemStyleProps>`
   a {
     ${({ theme }) => theme.typography.body2.semibold};
     color: ${({ theme, isActive }) => (isActive ? theme.semantic.label.normal : theme.semantic.label.alternative)};
+    ${({ theme, interactionVariant }) =>
+      getInteraction(interactionVariant, theme.semantic.label.alternative, false)(theme)};
+
+    display: flex;
+    align-items: center;
+
+    height: 3rem;
+    border-radius: ${({ theme }) => theme.radius[4]};
     outline: none;
     text-decoration: none;
   }

--- a/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.tsx
+++ b/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 
 import S, { SidebarNavItemStyleProps } from './SidebarNavItem.styled';

--- a/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.tsx
+++ b/src/app/mypage/_components/Sidebar/SidebarNavItem/SidebarNavItem.tsx
@@ -9,7 +9,10 @@ interface SidebarNavItemProps extends SidebarNavItemStyleProps {
 
 export default function SidebarNavItem({ label, href, isActive }: SidebarNavItemProps) {
   return (
-    <S.SidebarNavItem isActive={isActive}>
+    <S.SidebarNavItem
+      isActive={isActive}
+      interactionVariant='normal'
+    >
       <Link href={href}>{label}</Link>
     </S.SidebarNavItem>
   );

--- a/src/app/mypage/layout.styled.ts
+++ b/src/app/mypage/layout.styled.ts
@@ -14,6 +14,7 @@ const MainLayout = styled.div`
 
 const Layout = styled.div`
   display: flex;
+  gap: 6.2rem;
 `;
 
 const Content = styled.div`

--- a/src/app/mypage/layout.styled.ts
+++ b/src/app/mypage/layout.styled.ts
@@ -2,7 +2,7 @@
 
 import styled from '@emotion/styled';
 
-const MainLayout = styled.div`
+export const MainLayout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 5rem;
@@ -12,20 +12,12 @@ const MainLayout = styled.div`
   padding: 3.2rem 2rem;
 `;
 
-const Layout = styled.div`
+export const Layout = styled.div`
   display: flex;
   gap: 6.2rem;
 `;
 
-const Content = styled.div`
+export const Content = styled.div`
   display: flex;
   flex: 1;
 `;
-
-const S = {
-  MainLayout,
-  Layout,
-  Content,
-};
-
-export default S;

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -4,7 +4,7 @@ import MyPageBreadcrumb from './_components/MyPageBreadcrumb/MyPageBreadcrumb';
 import Sidebar from './_components/Sidebar/Sidebar';
 import S from './layout.styled';
 
-const MypageLayout = ({ children }: { children: React.ReactNode }) => {
+const MyPageLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <S.MainLayout>
       <MyPageBreadcrumb />
@@ -16,4 +16,4 @@ const MypageLayout = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-export default MypageLayout;
+export default MyPageLayout;

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import MyPageBreadcrumb from './_components/MyPageBreadcrumb/MyPageBreadcrumb';
 import Sidebar from './_components/Sidebar/Sidebar';
 import S from './layout.styled';
 
 const MypageLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <S.MainLayout>
+      <MyPageBreadcrumb />
       <S.Layout>
         <Sidebar />
         <S.Content>{children}</S.Content>

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -2,9 +2,9 @@
 
 import MyPageBreadcrumb from './_components/MyPageBreadcrumb/MyPageBreadcrumb';
 import Sidebar from './_components/Sidebar/Sidebar';
-import S from './layout.styled';
+import * as S from './layout.styled';
 
-const MyPageLayout = ({ children }: { children: React.ReactNode }) => {
+export default function MyPageLayout({ children }: { children: React.ReactNode }) {
   return (
     <S.MainLayout>
       <MyPageBreadcrumb />
@@ -14,6 +14,4 @@ const MyPageLayout = ({ children }: { children: React.ReactNode }) => {
       </S.Layout>
     </S.MainLayout>
   );
-};
-
-export default MyPageLayout;
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,3 +1,3 @@
-export default function Mypage() {
+export default function MyPage() {
   return <div>mypage</div>;
 }

--- a/src/app/mypage/setting/_components/EmailForm/EmailForm.styled.ts
+++ b/src/app/mypage/setting/_components/EmailForm/EmailForm.styled.ts
@@ -10,13 +10,8 @@ const EmailForm = styled.div`
   width: 100%;
 `;
 
-const ButtonWrapper = styled.div`
-  margin: 0.3rem 0;
-`;
-
 const S = {
   EmailForm,
-  ButtonWrapper,
 };
 
 export default S;

--- a/src/app/mypage/setting/_components/EmailForm/EmailForm.tsx
+++ b/src/app/mypage/setting/_components/EmailForm/EmailForm.tsx
@@ -62,17 +62,15 @@ export default function EmailForm() {
         error={errors.email?.message}
         width='34.5rem'
       />
-      <S.ButtonWrapper>
-        <OutlinedButton
-          type='button'
-          size='sm'
-          color='primary'
-          label={getLabel()}
-          onClick={handleClick}
-          interactionVariant='normal'
-          isDisabled={emailState === 'waiting' && isCooldown}
-        />
-      </S.ButtonWrapper>
+      <OutlinedButton
+        type='button'
+        size='md'
+        color='primary'
+        label={getLabel()}
+        onClick={handleClick}
+        interactionVariant='normal'
+        isDisabled={emailState === 'waiting' && isCooldown}
+      />
     </S.EmailForm>
   );
 }

--- a/src/app/mypage/setting/_components/EmailForm/EmailForm.tsx
+++ b/src/app/mypage/setting/_components/EmailForm/EmailForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
@@ -11,11 +10,14 @@ import { useCooldown } from '@/hooks/useCooldown';
 import { validateEmail } from '@/utils/validators/emailValidators';
 
 import S from './EmailForm.styled';
+import { EmailState } from '../../page';
 
-type EmailState = 'idle' | 'editing' | 'waiting' | 'verified';
+interface EmailFormProps {
+  emailState: EmailState;
+  setEmailState: (state: EmailState) => void;
+}
 
-export default function EmailForm() {
-  const [emailState, setEmailState] = useState<EmailState>('idle');
+export default function EmailForm({ emailState, setEmailState }: EmailFormProps) {
   const { value: isCooldown, start: startCooldown } = useCooldown(3000);
 
   const {
@@ -30,7 +32,7 @@ export default function EmailForm() {
   });
 
   const { checkEmailVerified } = useCheckEmailVerifiedMutation(() => {
-    setEmailState('idle');
+    setEmailState('verified');
   });
 
   const handleClick = () => {
@@ -58,7 +60,10 @@ export default function EmailForm() {
         label='이메일'
         required
         disabled={emailState === 'idle'}
-        {...register('email', { required: '이메일은 필수입니다.', validate: validateEmail })}
+        {...register('email', {
+          required: '이메일은 필수입니다.',
+          validate: validateEmail,
+        })}
         error={errors.email?.message}
         width='34.5rem'
       />

--- a/src/app/mypage/setting/page.styled.ts
+++ b/src/app/mypage/setting/page.styled.ts
@@ -18,6 +18,7 @@ const SetImage = styled.div`
 const SettingForm = styled.form`
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: ${({ theme }) => theme.spacing[16]};
 `;
 

--- a/src/app/mypage/setting/page.tsx
+++ b/src/app/mypage/setting/page.tsx
@@ -97,7 +97,7 @@ export default function Setting() {
 
         <S.ButtonWrapper>
           <OutlinedButton
-            size='sm'
+            size='md'
             color='primary'
             label='저장하기'
             interactionVariant='normal'

--- a/src/app/mypage/setting/page.tsx
+++ b/src/app/mypage/setting/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
@@ -13,6 +13,8 @@ import EmailForm from './_components/EmailForm/EmailForm';
 import SettingProfile from './_components/SettingProfile/SettingProfile';
 import S from './page.styled';
 
+export type EmailState = 'idle' | 'editing' | 'waiting' | 'verified';
+
 interface SettingFormFields {
   nickname: string;
   email: string;
@@ -21,17 +23,20 @@ interface SettingFormFields {
   imageUrl?: string;
 }
 
+const getDefaultValues = (data?: SettingFormFields): SettingFormFields => ({
+  nickname: data?.nickname ?? '',
+  email: data?.email ?? '',
+  phoneNumber: data?.phoneNumber ?? '',
+  description: data?.description ?? '',
+  imageUrl: data?.imageUrl,
+});
+
+const isEmailStateValid = (emailState: EmailState) => emailState === 'idle' || emailState === 'verified';
+
 export default function Setting() {
+  const [emailState, setEmailState] = useState<EmailState>('idle');
   const { data, isLoading } = useGetUserInfo();
   const { editUserInfo } = useEditUserInfoMutation();
-
-  const getDefaultValues = (data?: SettingFormFields): SettingFormFields => ({
-    nickname: data?.nickname ?? '',
-    email: data?.email ?? '',
-    phoneNumber: data?.phoneNumber ?? '',
-    description: data?.description ?? '',
-    imageUrl: data?.imageUrl,
-  });
 
   const methods = useForm<SettingFormFields>({
     mode: 'onChange',
@@ -64,9 +69,7 @@ export default function Setting() {
       <S.SettingForm onSubmit={handleSubmit(onSubmit)}>
         <SettingProfile
           imageUrl={data?.imageUrl}
-          onUploadComplete={(url) => {
-            setValue('imageUrl', url, { shouldValidate: true });
-          }}
+          onUploadComplete={(url) => setValue('imageUrl', url, { shouldValidate: true })}
         />
 
         <Input
@@ -78,7 +81,10 @@ export default function Setting() {
           width='34.5rem'
         />
 
-        <EmailForm />
+        <EmailForm
+          emailState={emailState}
+          setEmailState={setEmailState}
+        />
 
         <Input
           inputSize='md'
@@ -102,7 +108,7 @@ export default function Setting() {
             label='저장하기'
             interactionVariant='normal'
             type='submit'
-            isDisabled={!isValid}
+            isDisabled={!isValid || !isEmailStateValid(emailState)}
           />
         </S.ButtonWrapper>
       </S.SettingForm>


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #76

## 📋 작업 내용

- 사용자 정보 수정 -> 이메일 인증 X 시 저장버튼 disable처리

- 마이페이지 사이드바 스타일 수정

- 사이드바 use client

- 마이페이지에 Breadcrumb 추가

- discord 배포 알림 url 커스텀 도메인으로 변경

- 마이페이지 > 개인정보 설정 버튼 size md로 변경

- page, layout 스타일 파일 분리
styled.ts -> page.styled.ts, layout.styled.ts

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
