### PR TITLE
[FEAT] 로그아웃 구현 #86

### DIFF
--- a/src/api/authApis.ts
+++ b/src/api/authApis.ts
@@ -42,6 +42,14 @@ const checkEmailVerified = async ({ email }: CheckEmailVerifiedRequest) => {
   return data;
 };
 
+const logout = async () => {
+  const { data } = await axiosInstance.post<CheckEmailVerifiedRequest, AxiosResponse<ApiResponse>>(
+    END_POINTS_V1.AUTH.LOGOUT,
+  );
+
+  return data;
+};
+
 const reissueToken = async () => {
   const response = await axiosInstance.post<null, AxiosResponse>(END_POINTS_V1.AUTH.REISSUE_TOKEN, null, {
     useAuth: false,
@@ -57,5 +65,6 @@ export const authApi = {
   signup,
   sendEmail,
   checkEmailVerified,
+  logout,
   reissueToken,
 };

--- a/src/app/mypage/_components/Sidebar/Sidebar.tsx
+++ b/src/app/mypage/_components/Sidebar/Sidebar.tsx
@@ -6,12 +6,14 @@ import Setting from '@/assets/icons/setting.svg';
 import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
 import { SIDEBAR_NAV_ITEMS } from '@/constants/common';
 import useGetUserSummary from '@/hooks/api/member/useGetUserSummary';
+import { useModalStore } from '@/stores/useModalStore';
 
 import S from './Sidebar.styled';
 import SidebarNavItem from './SidebarNavItem/SidebarNavItem';
 
 export default function Sidebar() {
   const { data, isLoading } = useGetUserSummary();
+  const { open } = useModalStore();
   const router = useRouter();
   const pathname = usePathname() || '/';
 
@@ -43,7 +45,7 @@ export default function Sidebar() {
                 interactionVariant='normal'
               />
             ))}
-            <S.Logout>로그아웃</S.Logout>
+            <S.Logout onClick={() => open('logout', undefined)}>로그아웃</S.Logout>
           </S.SidebarNavList>
         </>
       )}

--- a/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
@@ -6,11 +6,12 @@ import styled from '@emotion/styled';
 import { getInteraction, InteractionVariant } from '@/styles/interaction';
 
 type OutlinedButtonColor = 'primary' | 'secondary' | 'assistive';
-type OutlinedButtonSize = 'sm' | 'md' | 'lg' | 'fillContainer';
+type OutlinedButtonSize = 'sm' | 'md' | 'lg';
 
 export interface OutlinedButtonStyleProps {
   color: OutlinedButtonColor;
   size: OutlinedButtonSize;
+  fillContainer?: boolean;
   interactionVariant: InteractionVariant;
 }
 
@@ -51,10 +52,6 @@ const sizeStyles: Record<OutlinedButtonSize, (theme: Theme) => SerializedStyles>
   lg: (theme) => css`
     ${theme.typography.body1.semibold}
   `,
-  fillContainer: (theme) => css`
-    ${theme.typography.body1.semibold};
-    width: 100%;
-  `,
 };
 
 const colorStyles: Record<OutlinedButtonColor, (theme: Theme, disable?: boolean) => SerializedStyles> = {
@@ -82,9 +79,16 @@ const getInteractionColor = (theme: Theme, color: OutlinedButtonColor) => {
   return theme.semantic.interaction.inactive;
 };
 
+const getFillContainerStyle = (fillContainer?: boolean) =>
+  fillContainer &&
+  css`
+    width: 100%;
+  `;
+
 const OutlinedButton = styled.button<OutlinedButtonStyleProps>`
   ${({ theme }) => commonStyles(theme)};
   ${({ theme, size }) => sizeStyles[size](theme)};
+  ${({ fillContainer }) => getFillContainerStyle(fillContainer)};
   ${({ theme, color }) => colorStyles[color](theme)};
   ${({ theme, interactionVariant, disabled, color }) =>
     getInteraction(interactionVariant, getInteractionColor(theme, color), disabled)(theme)};

--- a/src/components/atoms/OutlinedButton/OutlinedButton.tsx
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.tsx
@@ -17,6 +17,7 @@ export default function OutlinedButton({
   iconRight,
   color,
   size,
+  fillContainer,
   isDisabled,
   onClick,
   interactionVariant,
@@ -26,6 +27,7 @@ export default function OutlinedButton({
     <S.OutlinedButton
       size={size}
       color={color}
+      fillContainer={fillContainer}
       disabled={isDisabled}
       onClick={onClick}
       interactionVariant={interactionVariant}

--- a/src/components/organisms/Modal/Logout/Logout.styled.ts
+++ b/src/components/organisms/Modal/Logout/Logout.styled.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing[32]};
+
+  width: 40.7rem;
+  height: 45rem;
+  padding: 0 6rem;
+  background-color: ${({ theme }) => theme.semantic.background.normal.normal};
+  border-radius: ${({ theme }) => theme.radius[8]};
+`;
+
+export const Logout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing[24]};
+`;
+
+export const Mesage = styled.p`
+  ${({ theme }) => theme.typography.title3.bold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing[12]};
+`;
+
+export const Close = styled.div`
+  position: absolute;
+  top: 1.6rem;
+  right: 1.6rem;
+`;

--- a/src/components/organisms/Modal/Logout/Logout.tsx
+++ b/src/components/organisms/Modal/Logout/Logout.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import X from '@/assets/icons/x.svg';
+import IconButton from '@/components/atoms/IconButton/IconButton';
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import { useLogoutMutation } from '@/hooks/api/auth/useLogout';
+import { useModalStore } from '@/stores/useModalStore';
+
+import * as S from './Logout.styled';
+
+export default function Logout() {
+  const { close } = useModalStore();
+  const { logout } = useLogoutMutation();
+
+  return (
+    <S.Container>
+      <S.Close>
+        <IconButton
+          size='4rem'
+          variant='normal'
+          interactionVariant='normal'
+          onClick={close}
+        >
+          <X />
+        </IconButton>
+      </S.Close>
+
+      <S.Logout>
+        <S.Mesage>로그아웃 할까요?</S.Mesage>
+        <S.ButtonWrapper>
+          <OutlinedButton
+            size='lg'
+            color='assistive'
+            label='더 있을래요'
+            fillContainer
+            interactionVariant='normal'
+            onClick={close}
+          />
+          <OutlinedButton
+            size='lg'
+            color='primary'
+            label='네, 할게요'
+            fillContainer
+            interactionVariant='normal'
+            onClick={logout}
+          />
+        </S.ButtonWrapper>
+      </S.Logout>
+    </S.Container>
+  );
+}

--- a/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
@@ -49,10 +49,11 @@ export default function CheckEmail({ email, onConfirm, onChangeEmail }: CheckEma
         />
         <OutlinedButton
           label='다른 이메일 사용하기'
-          size='fillContainer'
+          size='md'
           color='assistive'
           interactionVariant='normal'
           onClick={onChangeEmail}
+          fillContainer
         />
       </S.ButtonWrapper>
     </>

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -3,11 +3,13 @@ import type { ModalMap } from '@/types/modal';
 import DailyAnswerEdit from './Daily/Edit/DailyAnswerEdit';
 import DailyAnswerPost, { DailyProps } from './Daily/Post/DailyAnswerPost';
 import Login from './Login/Login';
+import Logout from './Logout/Logout';
 import Signup, { SignupProps } from './Signup/Signup';
 
 export type AppModalProps = {
   login: undefined;
   signup: SignupProps;
+  logout: undefined;
   dailyAnswerPost: DailyProps;
   dailyAnswerEdit: undefined;
 };
@@ -19,6 +21,10 @@ export const modalRegistry: ModalMap<AppModalProps> = {
   },
   signup: {
     Component: Signup,
+    disableOutsideClick: false,
+  },
+  logout: {
+    Component: Logout,
     disableOutsideClick: false,
   },
   dailyAnswerPost: {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,8 +1,10 @@
 const AUTH_QUERY_KEYS = {
+  AUTH: ['auth'],
   AUTH_REISSUE: ['auth', 'reissue'],
 } as const;
 
 const MEMBER_QUERY_KEYS = {
+  MEMBER: ['member'],
   MEMBER_SUMMARY: ['member', 'info', 'summary'],
   MEMBER_INFO: ['member', 'info'],
 } as const;

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,17 +1,21 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { authApi } from '@/api/authApis';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { AUTH_QUERY_KEYS, MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
 
 export const useLogoutMutation = () => {
   const { clearToken } = useAuthStore();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: authApi.logout,
     onSuccess: () => {
       clearToken();
+      queryClient.resetQueries({ queryKey: AUTH_QUERY_KEYS.AUTH, exact: false });
+      queryClient.resetQueries({ queryKey: MEMBER_QUERY_KEYS.MEMBER, exact: false });
       router.push('/');
     },
     onError: () => {

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { authApi } from '@/api/authApis';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export const useLogoutMutation = () => {
+  const { clearToken } = useAuthStore();
+  const router = useRouter();
+
+  const mutation = useMutation({
+    mutationFn: authApi.logout,
+    onSuccess: () => {
+      clearToken();
+      router.push('/');
+    },
+    onError: () => {
+      alert('로그아웃에 실패했습니다.');
+    },
+  });
+
+  return { logout: mutation.mutate };
+};

--- a/src/hooks/api/auth/useLogout.ts
+++ b/src/hooks/api/auth/useLogout.ts
@@ -2,8 +2,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { authApi } from '@/api/authApis';
-import { useAuthStore } from '@/stores/useAuthStore';
 import { AUTH_QUERY_KEYS, MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 export const useLogoutMutation = () => {
   const { clearToken } = useAuthStore();

--- a/src/mocks/data/auth/logoutData.ts
+++ b/src/mocks/data/auth/logoutData.ts
@@ -1,0 +1,4 @@
+export const logoutSuccess = {
+  code: 'SUCCESS',
+  message: '로그아웃에 성공했습니다.',
+};

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -11,6 +11,7 @@ import {
   mockAccessToken,
   mockRefreshToken,
 } from '../data/auth/loginData';
+import { logoutSuccess } from '../data/auth/logoutData';
 import { reissueSuccess } from '../data/auth/reissueTokenData';
 import { sendEmailError, sendEmailSuccess } from '../data/auth/sendEmailData';
 import { signupError, signupSuccess } from '../data/auth/signupData';
@@ -82,6 +83,12 @@ export const authHandlers = [
     }
 
     return new HttpResponse(JSON.stringify(checkEmailVerifiedSuccess), {
+      status: HTTP_STATUS_CODE.OK,
+    });
+  }),
+
+  http.post(END_POINTS_V1.AUTH.LOGOUT, async () => {
+    return new HttpResponse(JSON.stringify(logoutSuccess), {
       status: HTTP_STATUS_CODE.OK,
     });
   }),

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -12,7 +12,7 @@ import {
   mockRefreshToken,
 } from '../data/auth/loginData';
 import { logoutSuccess } from '../data/auth/logoutData';
-import { reissueSuccess } from '../data/auth/reissueTokenData';
+import { reissueError, reissueSuccess } from '../data/auth/reissueTokenData';
 import { sendEmailError, sendEmailSuccess } from '../data/auth/sendEmailData';
 import { signupError, signupSuccess } from '../data/auth/signupData';
 
@@ -94,14 +94,19 @@ export const authHandlers = [
   }),
 
   http.post(END_POINTS_V1.AUTH.REISSUE_TOKEN, async () => {
-    return new HttpResponse(JSON.stringify(reissueSuccess), {
-      status: HTTP_STATUS_CODE.OK,
-      headers: new Headers([
-        ['Authorization', `Bearer ${mockAccessToken}`],
-        ['Access-Control-Expose-Headers', 'Authorization'],
-        ['Set-Cookie', `refreshToken=${mockRefreshToken}; HttpOnly; Path=/`],
-        ['Content-Type', 'application/json'],
-      ]),
+    // 로그아웃 시 사용
+    return new HttpResponse(JSON.stringify(reissueError), {
+      status: HTTP_STATUS_CODE.UNAUTHORIZED,
     });
+
+    // return new HttpResponse(JSON.stringify(reissueSuccess), {
+    //   status: HTTP_STATUS_CODE.OK,
+    //   headers: new Headers([
+    //     ['Authorization', `Bearer ${mockAccessToken}`],
+    //     ['Access-Control-Expose-Headers', 'Authorization'],
+    //     ['Set-Cookie', `refreshToken=${mockRefreshToken}; HttpOnly; Path=/`],
+    //     ['Content-Type', 'application/json'],
+    //   ]),
+    // });
   }),
 ];


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #86 

## 📋 작업 내용

## 로그아웃 api 로직 구현
로그아웃 시, 사용자 정보 관련 캐시를 함께 삭제하도록 처리했습니다.

```js
const AUTH_QUERY_KEYS = {
  AUTH: ['auth'],
  AUTH_REISSUE: ['auth', 'reissue'],
} as const;

const MEMBER_QUERY_KEYS = {
  MEMBER: ['member'],
  MEMBER_SUMMARY: ['member', 'info', 'summary'],
  MEMBER_INFO: ['member', 'info'],
} as const;
```

반복적인 쿼리 키 사용을 간소화하기 위해 AUTH_QUERY_KEYS.AUTH 및 MEMBER_QUERY_KEYS.MEMBER 등 상위 단위의 키를 추가로 정의했습니다.

## 🧪 모킹 환경에서 테스트 시 유의사항
로그아웃 이후에도 브라우저에는 HttpOnly 리프레시 토큰이 남아있기 때문에, 새로고침 시 자동으로 토큰 재발급 API가 호출됩니다.

이 경우 정상적으로 로그아웃 상태를 테스트하려면, reissueToken API의 모킹 응답을 실패(예: 401 Unauthorized)로 설정해주셔야 합니다.

## OutlinedButton에 fillContainer 속성 수정
로그아웃 모달에서 OutlinedButton이 lg 사이즈이면서 fillContainer 속성을 사용하고 있어, 해당 상황에 맞게 OutlinedButton 컴포넌트의 fillContainer 스타일을 수정했습니다.

따로 이슈파서 한번 싹 바꿔야할 것 같아요.

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
