### PR TITLE
[FEAT] 마이페이지 > 구매 기록 구현 #98

### DIFF
--- a/src/app/(shared)/(standard)/mypage/purchase/layout.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/purchase/layout.styled.ts
@@ -2,7 +2,7 @@
 
 import styled from '@emotion/styled';
 
-export const PurchaseContainer = styled.div`
+export const PurchaseLayout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4rem;

--- a/src/app/(shared)/(standard)/mypage/purchase/layout.tsx
+++ b/src/app/(shared)/(standard)/mypage/purchase/layout.tsx
@@ -1,0 +1,10 @@
+import * as S from './layout.styled';
+
+export default function PurchaseLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <S.PurchaseLayout>
+      <S.Heading>구매 기록</S.Heading>
+      {children}
+    </S.PurchaseLayout>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/purchase/page.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/purchase/page.styled.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const PurchaseContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  width: 100%;
+`;
+
+export const Heading = styled.p`
+  ${({ theme }) => theme.typography.heading1.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;

--- a/src/app/(shared)/(standard)/mypage/purchase/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/purchase/page.tsx
@@ -1,3 +1,13 @@
+import ScriptX from '@/assets/icons/script-x.svg';
+import EmptyState from '@/components/organisms/EmptyState/EmptyState';
+
+import * as S from './page.styled';
+
 export default function Purchase() {
-  return <div>purchase</div>;
+  return (
+    <S.PurchaseContainer>
+      <S.Heading>구매 기록</S.Heading>
+      <EmptyState icon={<ScriptX />} />
+    </S.PurchaseContainer>
+  );
 }

--- a/src/app/(shared)/(standard)/mypage/purchase/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/purchase/page.tsx
@@ -1,13 +1,6 @@
 import ScriptX from '@/assets/icons/script-x.svg';
 import EmptyState from '@/components/organisms/EmptyState/EmptyState';
 
-import * as S from './page.styled';
-
 export default function Purchase() {
-  return (
-    <S.PurchaseContainer>
-      <S.Heading>구매 기록</S.Heading>
-      <EmptyState icon={<ScriptX />} />
-    </S.PurchaseContainer>
-  );
+  return <EmptyState icon={<ScriptX />} />;
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #98

## 📋 작업 내용

- 구매 기록 화면 구현
- EmptyState 넣어뒀습니다!

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)

```js
    <S.PurchaseContainer>
      <S.Heading>구매 기록</S.Heading>
    </S.PurchaseContainer>
```

이 부분을 layout.ts 파일로 뺄지 고민됩니다! 마이페이지 > 커뮤니티 활동 같은 경우에는 레이아웃으로 빠질 것 같아서요!