### PR TITLE
[FEAT] accessToken 저장 및 로그인/회원가입 후 라우팅 처리 개선 #101

### DIFF
--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
 
-import { UserSummary } from '@/types/member';
 import { prefetchAuthAndUser } from '@/utils/api/prefetchAuthAndUser';
 
 import * as S from './Header.styled';
@@ -10,10 +9,13 @@ import RightNav from './RightNav/RightNav';
 export default async function Header() {
   const queryClient = new QueryClient();
 
-  let userSummary: UserSummary | undefined;
+  let accessToken: string | undefined;
+  let userSummary = undefined;
 
   try {
-    userSummary = await prefetchAuthAndUser(queryClient);
+    const result = await prefetchAuthAndUser(queryClient);
+    accessToken = result.accessToken;
+    userSummary = result.userSummary;
   } catch (err) {
     alert(`Auth prefetch failed: ${err}`);
   }
@@ -25,7 +27,10 @@ export default async function Header() {
       <S.Header>
         <S.Wrapper>
           <LeftNav />
-          <RightNav userSummary={userSummary} />
+          <RightNav
+            accessToken={accessToken}
+            userSummary={userSummary}
+          />
         </S.Wrapper>
       </S.Header>
     </HydrationBoundary>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -9,17 +9,7 @@ import RightNav from './RightNav/RightNav';
 export default async function Header() {
   const queryClient = new QueryClient();
 
-  let accessToken: string | undefined;
-  let userSummary = undefined;
-
-  try {
-    const result = await prefetchAuthAndUser(queryClient);
-    accessToken = result.accessToken;
-    userSummary = result.userSummary;
-  } catch (err) {
-    alert(`Auth prefetch failed: ${err}`);
-  }
-
+  const { accessToken, userSummary } = await prefetchAuthAndUser(queryClient);
   const dehydratedState = dehydrate(queryClient);
 
   return (

--- a/src/components/organisms/Header/RightNav/RightNav.tsx
+++ b/src/components/organisms/Header/RightNav/RightNav.tsx
@@ -28,7 +28,7 @@ export default function RightNav({ accessToken, userSummary: serverUserSummary }
   const { data: clientUserSummary } = useGetUserSummary();
 
   const userSummary = serverUserSummary ?? clientUserSummary;
-  const isLoggedIn = !!accessToken && !!userSummary;
+  const isLoggedIn = !!userSummary;
 
   useEffect(() => {
     if (accessToken) {

--- a/src/components/organisms/Header/RightNav/RightNav.tsx
+++ b/src/components/organisms/Header/RightNav/RightNav.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 import Bell from '@/assets/icons/bell.svg';
 import Search from '@/assets/icons/search.svg';
@@ -8,23 +9,32 @@ import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
 import IconButton from '@/components/atoms/IconButton/IconButton';
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
 import useGetUserSummary from '@/hooks/api/member/useGetUserSummary';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { useModalStore } from '@/stores/useModalStore';
 import { UserSummary } from '@/types/member';
 
 import S from './RightNav.styled';
 
 interface RightNavProps {
+  accessToken?: string;
   userSummary?: UserSummary;
 }
 
-export default function RightNav({ userSummary: serverUserSummary }: RightNavProps) {
+export default function RightNav({ accessToken, userSummary: serverUserSummary }: RightNavProps) {
   const { open } = useModalStore();
+  const { setToken } = useAuthStore();
   const router = useRouter();
 
   const { data: clientUserSummary } = useGetUserSummary();
 
   const userSummary = serverUserSummary ?? clientUserSummary;
-  const isLoggedIn = !!userSummary;
+  const isLoggedIn = !!accessToken && !!userSummary;
+
+  useEffect(() => {
+    if (accessToken) {
+      setToken(accessToken);
+    }
+  }, [accessToken]);
 
   return (
     <S.RightNav>

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -28,9 +28,9 @@ export const useLoginMutation = () => {
           email: socialUserInfo.email ?? '',
           nickname: socialUserInfo.nickname ?? '',
         });
-      } else {
-        router.push('/');
       }
+
+      router.push('/');
     },
     onError: () => {
       alert('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -16,6 +16,8 @@ export const useSignupMutation = () => {
       if (!!accessToken) {
         setToken(accessToken);
       }
+
+      router.push('/');
     },
     onError: () => {
       alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #101 

## 📋 작업 내용

- 로그인 및 회원가입 성공 시 라우팅 처리가 누락되어 있어 해당 로직을 추가했습니다.
(이전 로그인 로직 수정 중 빠졌던 부분입니다..ㅠ)

- prefetch를 통해 로그인 상태를 판별할 때 accessToken이 저장되지 않아
로그인이 되지 않은 것처럼 보이는 문제가 있어, accessToken 저장 로직도 추가했습니다.

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
