### PR TITLE
[FEAT] 마이페이지 > 커뮤니티 활동 구현 #96

### DIFF
--- a/src/app/(shared)/(standard)/mypage/community/comments/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/comments/page.tsx
@@ -1,0 +1,6 @@
+import MessageCircleX from '@/assets/icons/message-circle-x.svg';
+import EmptyState from '@/components/organisms/EmptyState/EmptyState';
+
+export default function Comments() {
+  return <EmptyState icon={<MessageCircleX />} />;
+}

--- a/src/app/(shared)/(standard)/mypage/community/layout.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/community/layout.styled.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const CommunityLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  width: 100%;
+`;
+
+export const CommunityHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+
+  width: 100%;
+`;
+
+export const Heading = styled.p`
+  ${({ theme }) => theme.typography.heading1.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;

--- a/src/app/(shared)/(standard)/mypage/community/layout.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/layout.tsx
@@ -1,0 +1,25 @@
+import TabBarList from '@/components/molecules/TabBarList/TabBarList';
+
+import * as S from './layout.styled';
+
+export default function CommunityLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <S.CommunityLayout>
+      <S.CommunityHeader>
+        <S.Heading>커뮤니티 활동</S.Heading>
+        <TabBarList
+          items={[
+            { label: '작성글', href: '/mypage/community/posts' },
+            { label: '댓글', href: '/mypage/community/comments' },
+            { label: '좋아요', href: '/mypage/community/likes' },
+          ]}
+          size='sm'
+          interactionVariant='normal'
+          fillContainer
+        />
+      </S.CommunityHeader>
+
+      {children}
+    </S.CommunityLayout>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/community/likes/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/likes/page.tsx
@@ -1,0 +1,6 @@
+import MessageCircleX from '@/assets/icons/message-circle-x.svg';
+import EmptyState from '@/components/organisms/EmptyState/EmptyState';
+
+export default function Likes() {
+  return <EmptyState icon={<MessageCircleX />} />;
+}

--- a/src/app/(shared)/(standard)/mypage/community/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from 'next/navigation';
+
 export default function Community() {
-  return <div>community</div>;
+  redirect('/mypage/community/posts');
 }

--- a/src/app/(shared)/(standard)/mypage/community/posts/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/posts/page.tsx
@@ -1,0 +1,6 @@
+import MessageCircleX from '@/assets/icons/message-circle-x.svg';
+import EmptyState from '@/components/organisms/EmptyState/EmptyState';
+
+export default function Posts() {
+  return <EmptyState icon={<MessageCircleX />} />;
+}

--- a/src/components/molecules/TabBarList/TabBarList.styled.ts
+++ b/src/components/molecules/TabBarList/TabBarList.styled.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Container = styled.div<{ fillContainer?: boolean }>`
+  display: flex;
+  ${({ fillContainer }) => fillContainer && 'width: 100%;'}
+  border-bottom: 1px solid ${({ theme }) => theme.semantic.line.neutral};
+`;

--- a/src/components/molecules/TabBarList/TabBarList.tsx
+++ b/src/components/molecules/TabBarList/TabBarList.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+import TabBar from '@/components/atoms/TabBar/TabBar';
+import { InteractionVariant } from '@/styles/interaction';
+
+import * as S from './TabBarList.styled';
+
+interface TabBarItem {
+  label: string;
+  href: string;
+}
+
+interface TabBarListProps {
+  items: TabBarItem[];
+  size?: 'sm' | 'md';
+  fillContainer?: boolean;
+  interactionVariant: InteractionVariant;
+}
+
+export default function TabBarList({ items, size = 'sm', fillContainer = false, interactionVariant }: TabBarListProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const handleTabClick = (href: string) => {
+    if (pathname !== href) {
+      router.push(href);
+    }
+  };
+
+  return (
+    <S.Container>
+      {items.map((item) => (
+        <TabBar
+          key={item.href}
+          label={item.label}
+          onChange={() => handleTabClick(item.href)}
+          size={size}
+          state={pathname === item.href}
+          fillContainer={fillContainer}
+          interactionVariant={interactionVariant}
+        />
+      ))}
+    </S.Container>
+  );
+}


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #96 

## 📋 작업 내용

- TabBarList 컴포넌트 구현
TabBarList는 내부에서 usePathname과 useRouter를 사용하고 있어, Storybook에서 스토리를 작성하려면 next/navigation을 별도로 mock 처리해야 합니다. 복잡한 설정을 피하기 위해 이번에는 스토리 작성을 생략했습니다. 다만, 필요하다고 생각되면 해당 설정을 진행하도록 하겠습니다. 의견 부탁드립니다!

- 사용자가 /mypage/community 로 들어올 경우를 대비해서 /posts로 redirect 시켰습니다!

- 각 페이지(posts, comments, likes)에 EmptyState 컴포넌트를 넣었습니다

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
