### PR TITLE
[FEAT] 마이페이지 > 푸시 및 카톡 알림 구현 #97

### DIFF
--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingGroup.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingGroup.styled.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const SettingGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+`;
+
+export const GroupTitle = styled.p`
+  ${({ theme }) => theme.typography.label1.medium};
+
+  color: ${({ theme }) => theme.semantic.label.alternative};
+  background-color: ${({ theme }) => theme.semantic.fill.normal};
+  padding: ${({ theme }) => theme.spacing[12]} ${({ theme }) => theme.spacing[32]};
+  border-radius: ${({ theme }) => theme.radius[12]};
+`;

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingGroup.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingGroup.tsx
@@ -1,0 +1,15 @@
+import * as S from './SettingGroup.styled';
+
+interface SettingGroupProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function SettingGroup({ title, children }: SettingGroupProps) {
+  return (
+    <S.SettingGroup>
+      <S.GroupTitle>{title}</S.GroupTitle>
+      {children}
+    </S.SettingGroup>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.styled.ts
@@ -2,16 +2,29 @@
 
 import styled from '@emotion/styled';
 
-export const SettingItem = styled.div`
+export const Container = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing[8]};
 
   width: 100%;
   padding: ${({ theme }) => theme.spacing[24]} ${({ theme }) => theme.spacing[32]};
 `;
 
+export const SettingItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+`;
+
 export const Label = styled.p`
   ${({ theme }) => theme.typography.body1.semibold};
-
   color: ${({ theme }) => theme.semantic.label.neutral};
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.primary.normal};
 `;

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.styled.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const SettingItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing[24]} ${({ theme }) => theme.spacing[32]};
+`;
+
+export const Label = styled.p`
+  ${({ theme }) => theme.typography.body1.semibold};
+
+  color: ${({ theme }) => theme.semantic.label.neutral};
+`;

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
@@ -1,0 +1,23 @@
+import Switch from '@/components/atoms/Switch/Switch';
+import * as S from './SettingItem.styled';
+
+interface SettingItemProps {
+  label: string;
+  isActive: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+}
+
+export default function SettingItem({ label, isActive, onChange, disabled }: SettingItemProps) {
+  return (
+    <S.SettingItem>
+      <S.Label>{label}</S.Label>
+      <Switch
+        size='md'
+        isActive={isActive}
+        isDisabled={disabled}
+        onChange={onChange}
+      />
+    </S.SettingItem>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
@@ -1,4 +1,5 @@
 import Switch from '@/components/atoms/Switch/Switch';
+
 import * as S from './SettingItem.styled';
 
 interface SettingItemProps {

--- a/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/_components/SettingGroup/SettingItem/SettingItem.tsx
@@ -4,21 +4,25 @@ import * as S from './SettingItem.styled';
 
 interface SettingItemProps {
   label: string;
+  description?: string;
   isActive: boolean;
   onChange: () => void;
   disabled?: boolean;
 }
 
-export default function SettingItem({ label, isActive, onChange, disabled }: SettingItemProps) {
+export default function SettingItem({ label, description, isActive, onChange, disabled }: SettingItemProps) {
   return (
-    <S.SettingItem>
-      <S.Label>{label}</S.Label>
-      <Switch
-        size='md'
-        isActive={isActive}
-        isDisabled={disabled}
-        onChange={onChange}
-      />
-    </S.SettingItem>
+    <S.Container>
+      <S.SettingItem>
+        <S.Label>{label}</S.Label>
+        <Switch
+          size='md'
+          isActive={isActive}
+          isDisabled={disabled}
+          onChange={onChange}
+        />
+      </S.SettingItem>
+      {description && <S.Description>{description}</S.Description>}
+    </S.Container>
   );
 }

--- a/src/app/(shared)/(standard)/mypage/notification/layout.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/notification/layout.styled.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const NotificationLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  width: 100%;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  width: 100%;
+`;
+
+export const Heading = styled.p`
+  ${({ theme }) => theme.typography.heading1.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => theme.typography.body2.regular};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+`;

--- a/src/app/(shared)/(standard)/mypage/notification/layout.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/layout.tsx
@@ -1,0 +1,13 @@
+import * as S from './layout.styled';
+
+export default function NotificationLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <S.NotificationLayout>
+      <S.TextWrapper>
+        <S.Heading>푸시 및 카톡 알림</S.Heading>
+        <S.Description>알림을 켜 두면 코그룸과 함께 더욱 성장할 수 있어요.</S.Description>
+      </S.TextWrapper>
+      {children}
+    </S.NotificationLayout>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/notification/page.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/notification/page.styled.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const NotificationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+`;

--- a/src/app/(shared)/(standard)/mypage/notification/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/page.tsx
@@ -10,7 +10,6 @@ export default function Notification() {
   const [settings, setSettings] = useState({
     push: true,
     sound: true,
-    kakao: false,
     news: true,
     streak: true,
     marketing: true,

--- a/src/app/(shared)/(standard)/mypage/notification/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import SettingItem from './_components/SettingGroup/SettingItem/SettingItem';
-import SettingGroup from './_components/SettingGroup/SettingGroup';
 
+import SettingGroup from './_components/SettingGroup/SettingGroup';
+import SettingItem from './_components/SettingGroup/SettingItem/SettingItem';
 import * as S from './page.styled';
 
 export default function Notification() {

--- a/src/app/(shared)/(standard)/mypage/notification/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/page.tsx
@@ -42,6 +42,7 @@ export default function Notification() {
         />
         <SettingItem
           label='스트릭 리마인드 알림'
+          description='시간 설정 10:00PM'
           isActive={settings.streak}
           onChange={() => toggle('streak')}
         />

--- a/src/app/(shared)/(standard)/mypage/notification/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/page.tsx
@@ -1,3 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import SettingItem from './_components/SettingGroup/SettingItem/SettingItem';
+import SettingGroup from './_components/SettingGroup/SettingGroup';
+
+import * as S from './page.styled';
+
 export default function Notification() {
-  return <div>notification</div>;
+  const [settings, setSettings] = useState({
+    push: true,
+    sound: true,
+    kakao: false,
+    news: true,
+    streak: true,
+    marketing: true,
+  });
+
+  const toggle = (key: keyof typeof settings) => {
+    setSettings((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <S.NotificationContainer>
+      <SettingGroup title='사이트 알림'>
+        <SettingItem
+          label='푸시 알림'
+          isActive={settings.push}
+          onChange={() => toggle('push')}
+        />
+        <SettingItem
+          label='소리 알림'
+          isActive={settings.sound}
+          onChange={() => toggle('sound')}
+        />
+      </SettingGroup>
+
+      <SettingGroup title='카카오톡 알림'>
+        <SettingItem
+          label='중요한 소식 알림'
+          isActive={settings.news}
+          onChange={() => toggle('news')}
+        />
+        <SettingItem
+          label='스트릭 리마인드 알림'
+          isActive={settings.streak}
+          onChange={() => toggle('streak')}
+        />
+        <SettingItem
+          label='마케팅 수신 동의'
+          isActive={settings.marketing}
+          onChange={() => toggle('marketing')}
+        />
+      </SettingGroup>
+    </S.NotificationContainer>
+  );
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #97 

## 📋 작업 내용

- 알림 리스트, 아이템 컴포넌트 구현
- 푸시 및 카톡 알림 페이지 구현

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
