### PR TITLE
[FIX] 토큰 재발급 버그 해결 #116

### DIFF
--- a/src/api/authApis.ts
+++ b/src/api/authApis.ts
@@ -50,13 +50,13 @@ const logout = async () => {
   return data;
 };
 
-const reissueToken = async () => {
+const reissueToken = async ({ cookie }: { cookie?: string } = {}) => {
   const response = await axiosInstance.post<null, AxiosResponse>(END_POINTS_V1.AUTH.REISSUE_TOKEN, null, {
+    headers: cookie ? { Cookie: cookie } : undefined,
     useAuth: false,
   });
 
   const accessToken = response.headers['authorization'];
-
   return { accessToken };
 };
 

--- a/src/api/axios/interceptors.ts
+++ b/src/api/axios/interceptors.ts
@@ -15,7 +15,10 @@ export interface ErrorResponseData {
 }
 
 export const checkAndSetToken = (config: InternalAxiosRequestConfig) => {
-  if (!config.useAuth || !config.headers || config.headers.Authorization) return config;
+  if (!config.useAuth || !config.headers || config.headers.Authorization) {
+    delete axios.defaults.headers.common.Authorization;
+    return config;
+  }
 
   const { accessToken, clearToken } = useAuthStore.getState();
 

--- a/src/utils/api/prefetchAuthAndUser.ts
+++ b/src/utils/api/prefetchAuthAndUser.ts
@@ -39,7 +39,7 @@ export async function prefetchAuthAndUser(queryClient: QueryClient): Promise<Pre
 
     return { accessToken, userSummary };
   } catch (err) {
-    alert(`Auth prefetch failed: ${err}`);
+    // alert(`Auth prefetch failed: ${err}`);
     return {};
   }
 }

--- a/src/utils/api/prefetchAuthAndUser.ts
+++ b/src/utils/api/prefetchAuthAndUser.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import { cookies } from 'next/headers';
 
 import { authApi } from '@/api/authApis';
 import { memberApi } from '@/api/memberApis';
@@ -12,9 +13,14 @@ interface PrefetchResult {
 
 export async function prefetchAuthAndUser(queryClient: QueryClient): Promise<PrefetchResult> {
   try {
+    const cookieHeader = cookies().toString();
+
     await queryClient.prefetchQuery({
       queryKey: [...AUTH_QUERY_KEYS.AUTH_REISSUE],
-      queryFn: authApi.reissueToken,
+      queryFn: () =>
+        authApi.reissueToken({
+          cookie: cookieHeader,
+        }),
     });
 
     const refreshResult = queryClient.getQueryData<{ accessToken: string }>(AUTH_QUERY_KEYS.AUTH_REISSUE);


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #116 

## 📋 작업 내용

- useAuth false 시 헤더에 들어가있는 토큰 제거
- next/headers로 prefetch 시 쿠키 가져오기

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
