### PR TITLE
[FEAT] 마이페이지 > 학습 및 활동기록 #113

### DIFF
--- a/src/api/memberApis.ts
+++ b/src/api/memberApis.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 
 import { END_POINTS_V1 } from '@/constants/api';
 import { ApiResponse } from '@/types/api';
-import { EditUserInfoRequest, UserInfoResponse, UserSummaryResponse } from '@/types/member';
+import { EditUserInfoRequest, UserDailyResponse, UserInfoResponse, UserSummaryResponse } from '@/types/member';
 
 import { axiosInstance } from './axios/axiosInstance';
 
@@ -17,6 +17,12 @@ export const getUserSummary = async (accessToken?: string) => {
 
 const getUserInfo = async () => {
   const { data } = await axiosInstance.get<UserInfoResponse>(END_POINTS_V1.MEMBERS.INFO);
+
+  return data.result;
+};
+
+const getUserDaily = async () => {
+  const { data } = await axiosInstance.get<UserDailyResponse>(END_POINTS_V1.MEMBERS.DAILY);
 
   return data.result;
 };
@@ -39,5 +45,6 @@ const editUserInfo = async ({ email, nickname, imageUrl, phoneNumber, descriptio
 export const memberApi = {
   getUserSummary,
   getUserInfo,
+  getUserDaily,
   editUserInfo,
 };

--- a/src/app/(shared)/(standard)/mypage/activity/contents/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/contents/page.tsx
@@ -1,0 +1,6 @@
+import ScriptX from '@/assets/icons/script-x.svg';
+import EmptyState from '@/components/organisms/EmptyState/EmptyState';
+
+export default function Contents() {
+  return <EmptyState icon={<ScriptX />} />;
+}

--- a/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.styled.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DailyQuestionCard = styled.div`
+  display: flex;
+  gap: 3.2rem;
+
+  width: 100%;
+`;
+
+export const QuestionAnswerGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  width: 100%;
+`;
+
+export const DateWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  padding: 0.6rem 0.15rem;
+`;
+
+export const DateText = styled.p`
+  ${({ theme }) => theme.typography.label2.regular};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+`;
+
+export const WeekdayText = styled.p`
+  ${({ theme }) => theme.typography.label2.semibold};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+`;

--- a/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
@@ -55,7 +55,9 @@ export default function DailyQuestionCard({
           <Textarea
             textareaSize='md'
             placeholder={answer}
+            minHeight='15.5rem'
             disabled
+            autoResize
           />
         )}
       </S.QuestionAnswerGroup>

--- a/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import dayjs from 'dayjs';
+import { useState } from 'react';
+
+import ChevronDown from '@/assets/icons/chevrondown.svg';
+import ChevronUp from '@/assets/icons/chevronup.svg';
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import Textarea from '@/components/molecules/Textarea/Textarea';
+import { formatDayAsSlashMMDD, formatDayAsWeekday } from '@/utils/formatDay';
+
+import * as S from './DailyQuestionCard.styled';
+
+interface DailyQuestionCardProps {
+  question: string;
+  answer: string;
+  assignedDate: string;
+  initialOpen?: boolean;
+}
+
+export default function DailyQuestionCard({
+  question,
+  answer,
+  assignedDate,
+  initialOpen = false,
+}: DailyQuestionCardProps) {
+  const [isOpen, setIsOpen] = useState(initialOpen);
+
+  const toggleOpen = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const date = dayjs(assignedDate);
+  const formattedDate = formatDayAsSlashMMDD(date);
+  const weekday = formatDayAsWeekday(date);
+
+  return (
+    <S.DailyQuestionCard>
+      <S.DateWrapper>
+        <S.DateText>{formattedDate}</S.DateText>
+        <S.WeekdayText>{weekday}</S.WeekdayText>
+      </S.DateWrapper>
+
+      <S.QuestionAnswerGroup>
+        <OutlinedButton
+          size='md'
+          color='assistive'
+          label={question}
+          iconRight={isOpen ? <ChevronUp /> : <ChevronDown />}
+          interactionVariant='normal'
+          fillContainer
+          onClick={toggleOpen}
+        />
+        {isOpen && (
+          <Textarea
+            textareaSize='md'
+            placeholder={answer}
+            disabled
+          />
+        )}
+      </S.QuestionAnswerGroup>
+    </S.DailyQuestionCard>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/activity/daily/page.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/page.styled.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DailyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+`;

--- a/src/app/(shared)/(standard)/mypage/activity/daily/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import useGetUserDailyQuery from '@/hooks/api/member/useGetUserDaily';
+
+import DailyQuestionCard from './_components/DailyQuestionCard/DailyQuestionCard';
+import * as S from './page.styled';
+
+export default function Daily() {
+  const { data, isLoading } = useGetUserDailyQuery();
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (!data?.length) return <div>데일리 질문이 없습니다.</div>;
+
+  return (
+    <S.DailyContainer>
+      {data.map(({ question, answer, assignedDate }, index) => (
+        <DailyQuestionCard
+          key={assignedDate}
+          question={question}
+          answer={answer}
+          assignedDate={assignedDate}
+          initialOpen={index === 0}
+        />
+      ))}
+    </S.DailyContainer>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/activity/layout.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/activity/layout.styled.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const ActivityLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  width: 100%;
+`;
+
+export const ActivityHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+
+  width: 100%;
+`;
+
+export const Heading = styled.p`
+  ${({ theme }) => theme.typography.heading1.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;

--- a/src/app/(shared)/(standard)/mypage/activity/layout.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/layout.tsx
@@ -1,0 +1,24 @@
+import TabBarList from '@/components/molecules/TabBarList/TabBarList';
+
+import * as S from './layout.styled';
+
+export default function ActivityLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <S.ActivityLayout>
+      <S.ActivityHeader>
+        <S.Heading>학습 및 활동기록</S.Heading>
+        <TabBarList
+          items={[
+            { label: '데일리', href: '/mypage/activity/daily' },
+            { label: '콘텐츠', href: '/mypage/activity/contents' },
+          ]}
+          size='sm'
+          interactionVariant='normal'
+          fillContainer
+        />
+      </S.ActivityHeader>
+
+      {children}
+    </S.ActivityLayout>
+  );
+}

--- a/src/app/(shared)/(standard)/mypage/activity/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/page.tsx
@@ -1,0 +1,3 @@
+export default function Activity() {
+  return <div>Activity</div>;
+}

--- a/src/app/(shared)/(standard)/mypage/activity/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from 'next/navigation';
+
 export default function Activity() {
-  return <div>Activity</div>;
+  redirect('/mypage/activity/daily');
 }

--- a/src/app/(shared)/(standard)/mypage/history/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/history/page.tsx
@@ -1,3 +1,0 @@
-export default function History() {
-  return <div>history</div>;
-}

--- a/src/app/(shared)/(standard)/mypage/setting/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/page.tsx
@@ -100,6 +100,7 @@ export default function Setting() {
           {...register('description')}
           error={errors.description?.message}
           width='34.5rem'
+          minHeight='12.8rem'
         />
 
         <S.ButtonWrapper>

--- a/src/app/(shared)/(standard)/mypage/setting/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/page.tsx
@@ -95,6 +95,7 @@ export default function Setting() {
         />
 
         <Textarea
+          textareaSize='md'
           label='자기소개'
           {...register('description')}
           error={errors.description?.message}

--- a/src/components/atoms/OutlinedButton/OutlinedButton.stories.tsx
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.stories.tsx
@@ -16,12 +16,15 @@ const meta = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md', 'lg', 'fillContainer'],
+      options: ['sm', 'md', 'lg'],
+    },
+    fillContainer: {
+      control: 'boolean',
+      description: '버튼 너비를 100%로 설정',
     },
     isDisabled: {
       control: 'boolean',
       description: '버튼 비활성화 여부',
-      defaultValue: false,
     },
     interactionVariant: {
       control: 'radio',
@@ -29,14 +32,13 @@ const meta = {
     },
     onClick: { action: 'clicked' },
     iconLeft: {
-      table: {
-        disable: true,
-      },
+      table: { disable: true },
     },
     iconRight: {
-      table: {
-        disable: true,
-      },
+      table: { disable: true },
+    },
+    hasIcon: {
+      table: { disable: true },
     },
   },
 } satisfies Meta<typeof OutlinedButton>;
@@ -49,6 +51,7 @@ export const NoIcon: Story = {
     label: 'Label',
     color: 'primary',
     size: 'md',
+    fillContainer: false,
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
@@ -61,6 +64,7 @@ export const LeftIconOnly: Story = {
     iconLeft: <Blank />,
     color: 'primary',
     size: 'md',
+    fillContainer: false,
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
@@ -73,45 +77,35 @@ export const RightIconOnly: Story = {
     iconRight: <Blank />,
     color: 'primary',
     size: 'md',
+    fillContainer: false,
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
 };
 
-export const Primary: Story = {
+export const LeftRightIcon: Story = {
   args: {
     label: 'Label',
     iconLeft: <Blank />,
     iconRight: <Blank />,
     color: 'primary',
     size: 'md',
+    fillContainer: false,
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
   },
 };
 
-export const Secondary: Story = {
+export const FillContainerWithIcons: Story = {
   args: {
-    label: 'Label',
+    label: 'Full Width',
     iconLeft: <Blank />,
     iconRight: <Blank />,
     color: 'secondary',
-    size: 'md',
-    isDisabled: false,
-    interactionVariant: 'normal',
-    onClick: action('clicked'),
-  },
-};
-
-export const Assistive: Story = {
-  args: {
-    label: 'Label',
-    iconLeft: <Blank />,
-    iconRight: <Blank />,
-    color: 'assistive',
-    size: 'md',
+    size: 'lg',
+    fillContainer: true,
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),

--- a/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
@@ -12,15 +12,17 @@ export interface OutlinedButtonStyleProps {
   color: OutlinedButtonColor;
   size: OutlinedButtonSize;
   fillContainer?: boolean;
+  hasIcon?: boolean;
   interactionVariant: InteractionVariant;
 }
 
-const commonStyles = (theme: Theme) => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, hasIcon?: boolean) => css`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: ${fillContainer && hasIcon ? 'space-between' : 'center'};
   gap: 4px;
 
+  width: ${fillContainer ? '100%' : 'auto'};
   border-radius: ${theme.radius[12]};
   border: 1px solid ${theme.semantic.primary.normal};
   color: ${theme.semantic.primary.normal};
@@ -54,7 +56,7 @@ const sizeStyles: Record<OutlinedButtonSize, (theme: Theme) => SerializedStyles>
   `,
 };
 
-const colorStyles: Record<OutlinedButtonColor, (theme: Theme, disable?: boolean) => SerializedStyles> = {
+const colorStyles: Record<OutlinedButtonColor, (theme: Theme) => SerializedStyles> = {
   primary: (theme) => css`
     border-color: ${theme.semantic.primary.normal};
     color: ${theme.semantic.primary.normal};
@@ -75,20 +77,12 @@ const getInteractionColor = (theme: Theme, color: OutlinedButtonColor) => {
   if (color === 'primary') {
     return theme.semantic.primary.normal;
   }
-
   return theme.semantic.interaction.inactive;
 };
 
-const getFillContainerStyle = (fillContainer?: boolean) =>
-  fillContainer &&
-  css`
-    width: 100%;
-  `;
-
 export const OutlinedButton = styled.button<OutlinedButtonStyleProps>`
-  ${({ theme }) => commonStyles(theme)};
+  ${({ theme, fillContainer, hasIcon }) => commonStyles(theme, fillContainer, hasIcon)};
   ${({ theme, size }) => sizeStyles[size](theme)};
-  ${({ fillContainer }) => getFillContainerStyle(fillContainer)};
   ${({ theme, color }) => colorStyles[color](theme)};
   ${({ theme, interactionVariant, disabled, color }) =>
     getInteraction(interactionVariant, getInteractionColor(theme, color), disabled)(theme)};

--- a/src/components/atoms/OutlinedButton/OutlinedButton.tsx
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.tsx
@@ -27,14 +27,15 @@ export default function OutlinedButton({
       size={size}
       color={color}
       fillContainer={fillContainer}
+      hasIcon={!!iconLeft || !!iconRight}
       disabled={isDisabled}
       onClick={onClick}
       interactionVariant={interactionVariant}
       type={type}
     >
-      <S.Icon>{iconLeft}</S.Icon>
+      {iconLeft && <S.Icon>{iconLeft}</S.Icon>}
       {label}
-      <S.Icon>{iconRight}</S.Icon>
+      {iconRight && <S.Icon>{iconRight}</S.Icon>}
     </S.OutlinedButton>
   );
 }

--- a/src/components/molecules/Textarea/Textarea.stories.tsx
+++ b/src/components/molecules/Textarea/Textarea.stories.tsx
@@ -26,10 +26,15 @@ const meta = {
     },
     error: {
       control: 'text',
+      description: `'normal:메시지', 'error:메시지' 등의 형식 사용`,
     },
     width: {
       control: 'text',
       description: '텍스트에어리어 너비 (예: "100%", "32rem")',
+    },
+    textareaSize: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
     },
     onChange: { action: 'changed' },
   },
@@ -41,12 +46,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: '소개글',
-    placeholder: 'Placeholder',
+    placeholder: '자기소개를 입력하세요',
     value: '',
     required: true,
     isDisabled: false,
     error: '',
     width: '32rem',
+    textareaSize: 'md',
   },
   render: (args) => {
     const [text, setText] = useState(args.value);

--- a/src/components/molecules/Textarea/Textarea.styled.ts
+++ b/src/components/molecules/Textarea/Textarea.styled.ts
@@ -9,6 +9,8 @@ export interface TextareaStyleProps {
   textareaSize: TextareaSize;
   isError?: boolean;
   width?: string;
+  minHeight?: string;
+  autoResize?: boolean;
 }
 
 const commonStyles = (theme: Theme) => css`
@@ -72,6 +74,8 @@ export const Textarea = styled.textarea<TextareaStyleProps>`
   ${({ theme, textareaSize }) => sizeStyles[textareaSize](theme)};
   ${({ theme, isError }) => isError && errorStyle(theme)};
   width: ${({ width }) => width || '100%'};
+  ${({ minHeight }) => minHeight && `min-height: ${minHeight};`}
+  ${({ autoResize }) => autoResize && 'overflow-y: hidden;'}
 `;
 
 export const Error = styled.p`

--- a/src/components/molecules/Textarea/Textarea.styled.ts
+++ b/src/components/molecules/Textarea/Textarea.styled.ts
@@ -1,9 +1,12 @@
 'use client';
 
-import { css, Theme } from '@emotion/react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
+type TextareaSize = 'sm' | 'md' | 'lg';
+
 export interface TextareaStyleProps {
+  textareaSize: TextareaSize;
   isError?: boolean;
   width?: string;
 }
@@ -39,6 +42,18 @@ const commonStyles = (theme: Theme) => css`
   }
 `;
 
+const sizeStyles: Record<TextareaSize, (theme: Theme) => SerializedStyles> = {
+  sm: (theme) => css`
+    ${theme.typography.label2.regular};
+  `,
+  md: (theme) => css`
+    ${theme.typography.label1.regular};
+  `,
+  lg: (theme) => css`
+    ${theme.typography.body1.regular};
+  `,
+};
+
 const errorStyle = (theme: Theme) => css`
   border-color: ${theme.semantic.status.destructive};
   &:hover {
@@ -54,6 +69,7 @@ export const Container = styled.div`
 
 export const Textarea = styled.textarea<TextareaStyleProps>`
   ${({ theme }) => commonStyles(theme)};
+  ${({ theme, textareaSize }) => sizeStyles[textareaSize](theme)};
   ${({ theme, isError }) => isError && errorStyle(theme)};
   width: ${({ width }) => width || '100%'};
 `;

--- a/src/components/molecules/Textarea/Textarea.tsx
+++ b/src/components/molecules/Textarea/Textarea.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, ComponentProps } from 'react';
+import { forwardRef, useEffect, useRef, ComponentProps } from 'react';
 
 import FormStatusMessage from '@/components/atoms/FormStatusMessage/FormStatusMessage';
 import { FormStatusMessageStatus } from '@/components/atoms/FormStatusMessage/FormStatusMessage.styled';
@@ -16,13 +16,23 @@ interface TextareaProps extends ComponentProps<'textarea'>, TextareaStyleProps {
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ label, textareaSize, required, isDisabled, error, width, ...props }, ref) => {
+  ({ label, textareaSize, required, isDisabled, error, width, minHeight, autoResize, ...props }, ref) => {
     const hasError = !!error;
     const [errorType, errorContent] = error?.split(':') ?? [];
 
     const isNormalError = errorType === 'normal';
     const isStatusError =
       errorType === 'error' || errorType === 'warning' || errorType === 'success' || errorType === 'disable';
+
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+    useEffect(() => {
+      if (autoResize && textareaRef.current) {
+        const el = textareaRef.current;
+        el.style.height = 'auto'; // reset height
+        el.style.height = `${el.scrollHeight}px`; // set new height
+      }
+    }, [props.value, autoResize]);
 
     return (
       <S.Container>
@@ -34,12 +44,18 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
 
         <S.Textarea
-          ref={ref}
+          ref={(node) => {
+            if (typeof ref === 'function') ref(node);
+            else if (ref) ref.current = node;
+            textareaRef.current = node;
+          }}
           textareaSize={textareaSize}
           disabled={isDisabled}
           isError={hasError}
           required={required}
           width={width}
+          minHeight={minHeight}
+          autoResize={autoResize}
           {...props}
         />
 

--- a/src/components/molecules/Textarea/Textarea.tsx
+++ b/src/components/molecules/Textarea/Textarea.tsx
@@ -16,7 +16,7 @@ interface TextareaProps extends ComponentProps<'textarea'>, TextareaStyleProps {
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ label, required, isDisabled, error, width, ...props }, ref) => {
+  ({ label, textareaSize, required, isDisabled, error, width, ...props }, ref) => {
     const hasError = !!error;
     const [errorType, errorContent] = error?.split(':') ?? [];
 
@@ -35,6 +35,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
         <S.Textarea
           ref={ref}
+          textareaSize={textareaSize}
           disabled={isDisabled}
           isError={hasError}
           required={required}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -30,7 +30,7 @@ export const END_POINTS_V1 = {
     SUMMARY: `${BASE_PATH_V1.MEMBERS}/me/summary`,
     INFO: `${BASE_PATH_V1.MEMBERS}/me`,
     INFO_EDIT: `${BASE_PATH_V1.MEMBERS}/me`,
-    DAILY: `${BASE_PATH_V1.MEMBERS}/daily`,
+    DAILY: `${BASE_PATH_V1.MEMBERS}/me/daily`,
     ORDERS: `${BASE_PATH_V1.MEMBERS}/orders`,
     SIGNOUT: `${BASE_PATH_V1.MEMBERS}/me`,
   },

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -6,7 +6,7 @@ export const HEADER_NAV_ITEMS = [
 
 export const SIDEBAR_NAV_ITEMS = [
   { label: '개인정보 설정', href: '/mypage/setting' },
-  { label: '학습 및 활동 기록', href: '/mypage/history' },
+  { label: '학습 및 활동 기록', href: '/mypage/activity' },
   { label: '구매 기록', href: '/mypage/purchase' },
   { label: '커뮤니티 활동', href: '/mypage/community' },
   { label: '푸시 및 카톡 알림', href: '/mypage/notification' },

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -5,8 +5,9 @@ const AUTH_QUERY_KEYS = {
 
 const MEMBER_QUERY_KEYS = {
   MEMBER: ['member'],
-  MEMBER_SUMMARY: ['member', 'info', 'summary'],
   MEMBER_INFO: ['member', 'info'],
+  MEMBER_SUMMARY: ['member', 'info', 'summary'],
+  MEMBER_DAILY: ['member', 'info', 'daily'],
 } as const;
 
 const DAILY_QUERY_KEYS = {

--- a/src/hooks/api/member/useGetUserDaily.ts
+++ b/src/hooks/api/member/useGetUserDaily.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { memberApi } from '@/api/memberApis';
+import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export default function useGetUserDailyQuery() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
+  return useQuery({
+    queryKey: [...MEMBER_QUERY_KEYS.MEMBER_DAILY],
+    queryFn: memberApi.getUserDaily,
+    enabled: isLoggedIn,
+  });
+}

--- a/src/hooks/api/member/useGetUserInfo.ts
+++ b/src/hooks/api/member/useGetUserInfo.ts
@@ -4,7 +4,7 @@ import { memberApi } from '@/api/memberApis';
 import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
 import { useAuthStore } from '@/stores/useAuthStore';
 
-export default function useGetUserInfoMutation() {
+export default function useGetUserInfoQuery() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   return useQuery({

--- a/src/hooks/api/member/useGetUserSummary.ts
+++ b/src/hooks/api/member/useGetUserSummary.ts
@@ -4,7 +4,7 @@ import { memberApi } from '@/api/memberApis';
 import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
 import { useAuthStore } from '@/stores/useAuthStore';
 
-export default function useGetUserSummary() {
+export default function useGetUserSummaryQuery() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   return useQuery({

--- a/src/mocks/data/member/getUserDailyData.ts
+++ b/src/mocks/data/member/getUserDailyData.ts
@@ -1,0 +1,16 @@
+export const getUserDailySuccess = {
+  code: 'SUCCESS',
+  message: '데일리 질문 및 답변 조회에 성공했습니다.',
+  result: [
+    {
+      question: '지금 가장 크게 느끼고 있는 감정은 어떤 감정 인가요?',
+      answer: '지금 느끼고 있는 감정은 여러가지인데, 그 중 무력함이 가장 커.',
+      assignedDate: '2025-06-15T15:39:11.012Z',
+    },
+    {
+      question: '밥 먹었어?',
+      answer: '안먹었어',
+      assignedDate: '2025-06-14T15:39:11.012Z',
+    },
+  ],
+};

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -4,6 +4,7 @@ import { END_POINTS_V1, HTTP_STATUS_CODE } from '@/constants/api';
 import { EditUserInfoRequest } from '@/types/member';
 
 import { editUserInfoError, editUserInfoSuccess } from '../data/member/editUserInfoData';
+import { getUserDailySuccess } from '../data/member/getUserDailyData';
 import { getUserInfoSuccess } from '../data/member/getUserInfoData';
 import { getUserSummarySuccess } from '../data/member/getUserSummaryData';
 
@@ -16,6 +17,12 @@ export const memberHandlers = [
 
   http.get(END_POINTS_V1.MEMBERS.INFO, async () => {
     return new HttpResponse(JSON.stringify(getUserInfoSuccess), {
+      status: HTTP_STATUS_CODE.OK,
+    });
+  }),
+
+  http.get(END_POINTS_V1.MEMBERS.DAILY, async () => {
+    return new HttpResponse(JSON.stringify(getUserDailySuccess), {
       status: HTTP_STATUS_CODE.OK,
     });
   }),

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -22,3 +22,13 @@ export interface UserInfoResponse extends ApiResponse {
 }
 
 export interface EditUserInfoRequest extends UserInfo {}
+
+export type UserDaily = {
+  question: string;
+  answer: string;
+  assignedDate: string;
+};
+
+export interface UserDailyResponse extends ApiResponse {
+  result: UserDaily[];
+}

--- a/src/utils/formatDay.ts
+++ b/src/utils/formatDay.ts
@@ -1,5 +1,7 @@
 import { Dayjs } from 'dayjs';
 
+import { WEEK_DAYS } from '@/constants/common';
+
 export function formatDayAsDashYYYYMMDD(date: Dayjs): string {
   return date.format('YYYY-MM-DD');
 }
@@ -14,4 +16,13 @@ export function formatDayAsSlashYYMMDD(date: Dayjs): string {
 
 export function formatDayAsSlashYYMMDDmmss(date: Dayjs): string {
   return date.format('YY/MM/DD mm:ss');
+}
+
+export function formatDayAsSlashMMDD(date: Dayjs): string {
+  return date.format('MM/DD');
+}
+
+export function formatDayAsWeekday(date: Dayjs): string {
+  const dayIndex = date.day(); // dayjs에서 0: 일요일 ~ 6: 토요일
+  return WEEK_DAYS[dayIndex === 0 ? 6 : dayIndex - 1];
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #113 

## 📋 작업 내용

### 데일리 질문/답변 리스트 API 연동
유저의 데일리 질문 및 답변을 리스트로 받아올 수 있도록 API 연동 로직을 구현했습니다.

### 날짜 포맷 유틸 함수 추가
- MM/DD 형식으로 날짜를 포맷하는 함수
- 요일(월~일)로 변환하는 함수
→ dayjs 기반으로 유틸 함수로 분리했습니다.

### 라우팅 경로 변경
기존 history 경로를 activity로 변경하여 기능 목적에 더 맞도록 수정했습니다.

### Textarea 컴포넌트 수정
- size 속성(sm, md, lg) 추가
디자인팀과 높이 및 resize 정책에 대한 협의가 필요합니다.
예: 고정 높이 vs 글자 수에 따라 자동 확장 등
=> 협의 후 결과 : minHeight 추가 및 autoResize 추가로 글자 수에 따라 자동 확장 가능하도록 변경

### OutlinedButton 컴포넌트 수정
- fillContainer 옵션 사용 시 아이콘이 있을 경우 justify-content: space-between 처리되도록 수정했습니다.

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
