### PR TITLE
[FEAT] Select 컴포넌트 구현 #150

### DIFF
--- a/src/components/atoms/Checkbox/Checkbox.tsx
+++ b/src/components/atoms/Checkbox/Checkbox.tsx
@@ -7,6 +7,7 @@ interface CheckboxProps extends CheckboxStyleProps {
   onToggle: (checked: boolean) => void;
   required?: boolean;
   name?: string;
+  tabIndex?: number;
 }
 
 export default function Checkbox({
@@ -18,6 +19,7 @@ export default function Checkbox({
   required = false,
   name,
   round,
+  tabIndex,
 }: CheckboxProps) {
   const handleClick = () => {
     if (!isDisabled) {
@@ -33,6 +35,7 @@ export default function Checkbox({
       interactionVariant={interactionVariant}
       onClick={handleClick}
       round={round}
+      tabIndex={tabIndex}
     >
       <S.HiddenCheckbox
         type='checkbox'

--- a/src/components/atoms/DropdownItem/DropdownItem.styled.ts
+++ b/src/components/atoms/DropdownItem/DropdownItem.styled.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DropdownItem = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  width: 100%;
+  padding: 1.2rem 1.6rem;
+  border-radius: 1.2rem;
+
+  ${({ theme }) => theme.typography.body1.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+  background-color: ${({ theme }) => theme.semantic.static.white};
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background-color: ${({ theme }) => theme.semantic.background.elevated.normal};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/atoms/DropdownItem/DropdownItem.tsx
+++ b/src/components/atoms/DropdownItem/DropdownItem.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import Checkbox from '@/components/atoms/Checkbox/Checkbox';
+import Radio from '@/components/atoms/Radio/Radio';
+
+import * as S from './DropdownItem.styled';
+
+interface DropdownItemProps {
+  label: string;
+  value: string;
+  isChecked: boolean;
+  isMulti: boolean;
+  groupName?: string;
+  onToggle: (value: string, checked: boolean) => void;
+}
+
+export function DropdownItem({ label, value, isChecked, isMulti, groupName, onToggle }: DropdownItemProps) {
+  const handleClick = () => {
+    onToggle(value, !isChecked);
+  };
+
+  return (
+    <S.DropdownItem
+      type='button'
+      onClick={handleClick}
+      aria-pressed={isChecked}
+      data-checked={isChecked}
+    >
+      {isMulti ? (
+        <Checkbox
+          size='sm'
+          isDisabled={false}
+          isChecked={isChecked}
+          interactionVariant='strong'
+          onToggle={() => {}}
+          name={value}
+          tabIndex={-1}
+        />
+      ) : (
+        <Radio
+          size='sm'
+          isDisabled={false}
+          isChecked={isChecked}
+          interactionVariant='strong'
+          onToggle={() => {}}
+          name={groupName}
+          tabIndex={-1}
+        />
+      )}
+      {label}
+    </S.DropdownItem>
+  );
+}

--- a/src/components/atoms/Radio/Radio.tsx
+++ b/src/components/atoms/Radio/Radio.tsx
@@ -5,6 +5,7 @@ interface RadioProps extends RadioStyleProps {
   onToggle: (checked: boolean) => void;
   required?: boolean;
   name?: string;
+  tabIndex?: number;
 }
 
 export default function Radio({
@@ -15,6 +16,7 @@ export default function Radio({
   required = false,
   name,
   interactionVariant,
+  tabIndex,
 }: RadioProps) {
   const handleClick = () => {
     if (!isDisabled) {
@@ -36,6 +38,7 @@ export default function Radio({
         size={size}
         isDisabled={isDisabled}
         isChecked={isChecked}
+        tabIndex={tabIndex}
         interactionVariant={interactionVariant}
       >
         <S.RadioInner />

--- a/src/components/molecules/DropdownList/DropdownList.styled.ts
+++ b/src/components/molecules/DropdownList/DropdownList.styled.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DropdownList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  padding: 0.4rem 0.8rem;
+  border-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.semantic.static.white};
+`;

--- a/src/components/molecules/DropdownList/DropdownList.tsx
+++ b/src/components/molecules/DropdownList/DropdownList.tsx
@@ -1,0 +1,38 @@
+import { DropdownItem } from '@/components/atoms/DropdownItem/DropdownItem';
+
+import * as S from './DropdownList.styled';
+
+interface DropdownListProps {
+  options: { label: string; value: string }[];
+  selectedValues: string[];
+  isMulti: boolean;
+  groupName?: string;
+  onSelect: (value: string[]) => void;
+}
+
+export function DropdownList({ options, selectedValues, isMulti, groupName, onSelect }: DropdownListProps) {
+  const handleToggle = (value: string, checked: boolean) => {
+    if (isMulti) {
+      const next = checked ? [...selectedValues, value] : selectedValues.filter((v) => v !== value);
+      onSelect(next);
+    } else {
+      onSelect([value]);
+    }
+  };
+
+  return (
+    <S.DropdownList>
+      {options.map((option) => (
+        <DropdownItem
+          key={option.value}
+          label={option.label}
+          value={option.value}
+          isChecked={selectedValues.includes(option.value)}
+          isMulti={isMulti}
+          onToggle={handleToggle}
+          groupName={groupName}
+        />
+      ))}
+    </S.DropdownList>
+  );
+}

--- a/src/components/molecules/Select/Select.stories.tsx
+++ b/src/components/molecules/Select/Select.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Select } from './Select';
 
 const meta = {
-  title: 'Components/Select',
+  title: 'components/molecules/Select',
   component: Select,
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/molecules/Select/Select.stories.tsx
+++ b/src/components/molecules/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 import { Select } from './Select';
 

--- a/src/components/molecules/Select/Select.stories.tsx
+++ b/src/components/molecules/Select/Select.stories.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Select } from './Select';
+
+const meta = {
+  title: 'Components/Select',
+  component: Select,
+  tags: ['autodocs'],
+  argTypes: {
+    options: { control: false },
+    onChange: { action: 'changed' },
+    groupName: { table: { disable: true } },
+    value: { table: { disable: true } },
+  },
+} satisfies Meta<typeof Select>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const OPTIONS = [
+  { label: '사과', value: 'apple' },
+  { label: '바나나', value: 'banana' },
+  { label: '포도', value: 'grape' },
+  { label: '딸기', value: 'strawberry' },
+];
+
+export const SingleSelect: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<string[]>([]);
+
+    return (
+      <Select
+        {...args}
+        value={value}
+        onChange={setValue}
+        options={OPTIONS}
+      />
+    );
+  },
+  args: {
+    placeholder: '과일을 선택하세요',
+    isMulti: false,
+    label: '과일',
+    required: true,
+    error: '',
+    options: [],
+    value: [],
+    onChange: () => {},
+  },
+};
+
+export const MultiSelect: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<string[]>([]);
+
+    return (
+      <Select
+        {...args}
+        value={value}
+        onChange={setValue}
+        options={OPTIONS}
+      />
+    );
+  },
+  args: {
+    placeholder: '과일을 검색해 선택하세요',
+    isMulti: true,
+    label: '과일',
+    required: true,
+    error: '',
+    options: [],
+    value: [],
+    onChange: () => {},
+  },
+};

--- a/src/components/molecules/Select/Select.styled.ts
+++ b/src/components/molecules/Select/Select.styled.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export interface SelectStyleProps {
+  isError?: boolean;
+  isOpen?: boolean;
+}
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  width: 100%;
+`;
+
+export const DropdownContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const InputContainer = styled.div<SelectStyleProps>`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
+  width: 100%;
+  padding: 1.1rem 1.5rem;
+  border-radius: 1.2rem;
+
+  border: 1px solid
+    ${({ theme, isError, isOpen }) =>
+      isError
+        ? theme.semantic.status.destructive
+        : isOpen
+          ? theme.semantic.primary.normal
+          : theme.semantic.label.assistive};
+
+  cursor: pointer;
+`;
+
+export const TriggerInput = styled.input`
+  flex: 1;
+
+  border: none;
+  background: transparent;
+
+  ${({ theme }) => theme.typography.body1.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  cursor: pointer;
+
+  &::placeholder {
+    ${({ theme }) => theme.typography.body1.regular};
+    color: ${({ theme }) => theme.semantic.label.assistive};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const IconWrapper = styled.div<SelectStyleProps>`
+  width: 1.6rem;
+  height: 1.6rem;
+
+  position: absolute;
+  top: 50%;
+  right: 1.58rem;
+  transform: translateY(-50%);
+  z-index: 1;
+
+  color: ${({ theme, isError, isOpen }) =>
+    isError
+      ? theme.semantic.status.destructive
+      : isOpen
+        ? theme.semantic.primary.normal
+        : theme.semantic.label.alternative};
+`;
+
+export const DropdownPanel = styled.div`
+  position: absolute;
+  z-index: 100;
+  top: 100%;
+  left: 0;
+  right: 0;
+
+  margin-top: 0.7rem;
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.semantic.static.white};
+
+  ${({ theme }) => theme.shadow.normal};
+`;
+
+export const ErrorText = styled.p`
+  ${({ theme }) => theme.typography.label2.regular};
+  color: ${({ theme }) => theme.semantic.status.destructive};
+`;

--- a/src/components/molecules/Select/Select.tsx
+++ b/src/components/molecules/Select/Select.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React from 'react';
+import * as S from './Select.styled';
+import { DropdownList } from '../DropdownList/DropdownList';
+import { useDropdown } from '@/hooks/useDropdown';
+import ChevronDown from '@/assets/icons/chevrondown.svg';
+import InputLabel from '@/components/atoms/InputLabel/InputLabel';
+import { SelectTagList } from './SelectTagList/SelectTagList';
+import { SelectOption } from '@/types/common';
+
+interface SelectProps {
+  options: SelectOption[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  isMulti?: boolean;
+  placeholder?: string;
+  groupName?: string;
+  error?: string;
+  label?: string;
+  required?: boolean;
+}
+
+export function Select({
+  options,
+  value,
+  onChange,
+  isMulti = false,
+  placeholder,
+  groupName,
+  error,
+  label,
+  required = false,
+}: SelectProps) {
+  const { isOpen, toggle, handleBlur, dropdownRef } = useDropdown();
+
+  const selectedLabels = options.filter((opt) => value.includes(opt.value)).map((opt) => opt.label);
+
+  const handleSelect = (next: string[]) => {
+    onChange(next);
+    if (!isMulti) toggle();
+  };
+
+  const handleRemove = (val: string) => {
+    onChange(value.filter((v) => v !== val));
+  };
+
+  return (
+    <S.Wrapper>
+      {label && (
+        <InputLabel
+          label={label}
+          required={required}
+        />
+      )}
+
+      <S.DropdownContainer
+        ref={dropdownRef}
+        onBlur={handleBlur}
+        tabIndex={-1}
+      >
+        <S.InputContainer
+          isOpen={isOpen}
+          isError={!!error}
+          onClick={toggle}
+        >
+          {isMulti && (
+            <SelectTagList
+              options={options}
+              value={value}
+              onRemove={handleRemove}
+            />
+          )}
+
+          <S.TriggerInput
+            type='text'
+            readOnly
+            value={isMulti ? '' : selectedLabels[0] || ''}
+            placeholder={value.length === 0 ? placeholder : ''}
+          />
+
+          <S.IconWrapper
+            isOpen={isOpen}
+            isError={!!error}
+          >
+            <ChevronDown />
+          </S.IconWrapper>
+        </S.InputContainer>
+
+        {isOpen && (
+          <S.DropdownPanel role='listbox'>
+            <DropdownList
+              options={options}
+              selectedValues={value}
+              isMulti={isMulti}
+              onSelect={handleSelect}
+              groupName={groupName}
+            />
+          </S.DropdownPanel>
+        )}
+      </S.DropdownContainer>
+
+      {error && <S.ErrorText role='alert'>{error}</S.ErrorText>}
+    </S.Wrapper>
+  );
+}

--- a/src/components/molecules/Select/Select.tsx
+++ b/src/components/molecules/Select/Select.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import React from 'react';
-import * as S from './Select.styled';
-import { DropdownList } from '../DropdownList/DropdownList';
-import { useDropdown } from '@/hooks/useDropdown';
+
 import ChevronDown from '@/assets/icons/chevrondown.svg';
 import InputLabel from '@/components/atoms/InputLabel/InputLabel';
-import { SelectTagList } from './SelectTagList/SelectTagList';
+import { useDropdown } from '@/hooks/useDropdown';
 import { SelectOption } from '@/types/common';
+
+import * as S from './Select.styled';
+import { DropdownList } from '../DropdownList/DropdownList';
+import { SelectTagList } from './SelectTagList/SelectTagList';
 
 interface SelectProps {
   options: SelectOption[];

--- a/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.styled.ts
+++ b/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.styled.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Tag = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  padding: 0.3rem 0.56rem;
+  background-color: rgba(70, 119, 200, 0.075);
+  border-radius: 0.4rem;
+`;
+
+export const TagLabel = styled.p`
+  ${({ theme }) => theme.typography.label2.semibold};
+  color: ${({ theme }) => theme.semantic.primary.normal};
+`;
+
+export const TagRemoveButton = styled.button`
+  width: 1.6rem;
+  height: 1.6rem;
+
+  color: ${({ theme }) => theme.semantic.primary.normal};
+  background-color: transparent;
+`;

--- a/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.tsx
+++ b/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+
+import * as S from './SelectTag.styled';
+import X from '@/assets/icons/x.svg';
+
+interface SelectTagProps {
+  label: string;
+  onRemove: () => void;
+}
+
+export function SelectTag({ label, onRemove }: SelectTagProps) {
+  return (
+    <S.Tag>
+      <S.TagLabel>{label}</S.TagLabel>
+      <S.TagRemoveButton onClick={onRemove}>
+        <X />
+      </S.TagRemoveButton>
+    </S.Tag>
+  );
+}

--- a/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.tsx
+++ b/src/components/molecules/Select/SelectTagList/SelectTag/SelectTag.tsx
@@ -2,8 +2,9 @@
 
 import React from 'react';
 
-import * as S from './SelectTag.styled';
 import X from '@/assets/icons/x.svg';
+
+import * as S from './SelectTag.styled';
 
 interface SelectTagProps {
   label: string;

--- a/src/components/molecules/Select/SelectTagList/SelectTagList.styled.ts
+++ b/src/components/molecules/Select/SelectTagList/SelectTagList.styled.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const SelectTagList = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+`;

--- a/src/components/molecules/Select/SelectTagList/SelectTagList.tsx
+++ b/src/components/molecules/Select/SelectTagList/SelectTagList.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { SelectTag } from './SelectTag/SelectTag';
+import * as S from './SelectTagList.styled';
+import { SelectOption } from '@/types/common';
+
+interface SelectTagListProps {
+  options: SelectOption[];
+  value: string[];
+  onRemove: (val: string) => void;
+}
+
+export function SelectTagList({ options, value, onRemove }: SelectTagListProps) {
+  return (
+    <S.SelectTagList>
+      {value.map((val) => {
+        const item = options.find((opt) => opt.value === val);
+        return (
+          <SelectTag
+            key={val}
+            label={item?.label || val}
+            onRemove={() => onRemove(val)}
+          />
+        );
+      })}
+    </S.SelectTagList>
+  );
+}

--- a/src/components/molecules/Select/SelectTagList/SelectTagList.tsx
+++ b/src/components/molecules/Select/SelectTagList/SelectTagList.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import React from 'react';
+
+import { SelectOption } from '@/types/common';
+
 import { SelectTag } from './SelectTag/SelectTag';
 import * as S from './SelectTagList.styled';
-import { SelectOption } from '@/types/common';
 
 interface SelectTagListProps {
   options: SelectOption[];

--- a/src/hooks/useDropdown.ts
+++ b/src/hooks/useDropdown.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState, useRef } from 'react';
+
+export function useDropdown(onBlurCallback?: () => void) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const toggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    if (!dropdownRef.current?.contains(event.relatedTarget)) {
+      setIsOpen(false);
+      onBlurCallback?.();
+    }
+  };
+
+  return { isOpen, toggle, handleBlur, dropdownRef };
+}

--- a/src/styles/foundation.ts
+++ b/src/styles/foundation.ts
@@ -54,6 +54,12 @@ export const ratio = {
 } as const;
 
 export const shadow: Shadow = {
+  normal: css`
+    box-shadow:
+      0px 0px 1px rgba(0, 0, 0, 0.08),
+      0px 0px 1px rgba(0, 0, 0, 0.08),
+      0px 1px 2px rgba(0, 0, 0, 0.12);
+  `,
   emphasize: css`
     box-shadow:
       0px 0px 1px rgba(0, 0, 0, 0.08),

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -23,7 +23,7 @@ export type Typography = {
   caption2: Pick<TypographyStyle, 'regular' | 'medium' | 'semibold'>;
 };
 
-type ShadowLevel = 'emphasize' | 'strong' | 'heavy';
+type ShadowLevel = 'normal' | 'emphasize' | 'strong' | 'heavy';
 
 export type Shadow = {
   [key in ShadowLevel]: SerializedStyles;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,4 @@
+export interface SelectOption {
+  label: string;
+  value: string;
+}


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #150 

## 📋 작업 내용

- useDropdown 훅 구현
- shadow에 normal 옵션 추가
- Checkbox, Radio 컴포넌트에 tabIndex props를 추가했습니다.
드롭다운 내에서 키보드 접근 시, 드롭다운 아이템에 포커스가 한 번 갔다면 이후 Tab 키를 눌렀을 때 Checkbox나 Radio로 포커스가 이동하지 않도록 하기 위함입니다!
현재는 Checkbox와 Radio에만 적용했지만, 추후 필요 시 다른 컴포넌트에도 확장하거나 전반적인 포커스 흐름을 고려해 리팩토링이 필요할 수 있습니다.
- Select 컴포넌트 구현
일단 구현이 급해서 리팩토링을 많이 하지는 못했어요.. 3차 이후에 리팩토링 해보도록 하겠습니다!

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
