### PR TITLE
[FEAT] daily first answer #142

### DIFF
--- a/src/api/dailyApis.ts
+++ b/src/api/dailyApis.ts
@@ -3,10 +3,17 @@ import type { AxiosResponse } from 'axios';
 import { axiosInstance } from '@/api/axios/axiosInstance';
 import { END_POINTS_V1 } from '@/constants/api';
 import { ApiResponse } from '@/types/api';
-import { DailyAnswerRequest, DailyQuestionResponse } from '@/types/daily';
+import { DailyAnswerRequest, DailyHasAnsweredResponse, DailyQuestionResponse } from '@/types/daily';
 
 const getDaily = async () => {
   const { data } = await axiosInstance.get<DailyQuestionResponse>(END_POINTS_V1.DAILY.QUESTIONS, {
+    useAuth: true,
+  });
+  return data;
+};
+
+const getDailyHasAnswered = async () => {
+  const { data } = await axiosInstance.get<DailyHasAnsweredResponse>(END_POINTS_V1.DAILY.HAS_ANSWERED, {
     useAuth: true,
   });
   return data;
@@ -34,4 +41,5 @@ export const dailyApi = {
   getDaily,
   submitDailyAnswer,
   editDailyAnswer,
+  getDailyHasAnswered,
 };

--- a/src/api/streakApis.ts
+++ b/src/api/streakApis.ts
@@ -1,13 +1,20 @@
 import { END_POINTS_V1 } from '@/constants/api';
-import { StreakDateListResponse } from '@/types/streak';
+import { StreakCalendarResponse, StreakDaysResponse } from '@/types/streak';
 
 import { axiosInstance } from './axios/axiosInstance';
 
-const getStreakDateList = async () => {
-  const { data } = await axiosInstance.get<StreakDateListResponse>(END_POINTS_V1.STREAKS.CALENDAR, { useAuth: true });
+const getStreakCalendar = async () => {
+  const { data } = await axiosInstance.get<StreakCalendarResponse>(END_POINTS_V1.STREAKS.CALENDAR, { useAuth: true });
   return data;
 };
 
+const getStreakDays = async () => {
+  const { data } = await axiosInstance.get<StreakDaysResponse>(END_POINTS_V1.STREAKS.DAILY_STREAK, { useAuth: true });
+  return data;
+};
+
+
 export const streakApi = {
-  getStreakDateList,
+  getStreakCalendar,
+  getStreakDays,
 };

--- a/src/api/streakApis.ts
+++ b/src/api/streakApis.ts
@@ -13,7 +13,6 @@ const getStreakDays = async () => {
   return data;
 };
 
-
 export const streakApi = {
   getStreakCalendar,
   getStreakDays,

--- a/src/app/(shared)/(standard)/daily/_components/Calendar/Calendar.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Calendar/Calendar.tsx
@@ -19,9 +19,9 @@ interface CalendarProps {
 
 export default function Calendar({ streakDateList }: CalendarProps) {
   const router = useRouter();
-  const [isMonthly, setIsMonthly] = useState(false);
   const today = dayjs();
 
+  const [isMonthly, setIsMonthly] = useState(false);
   const monthDates = useMemo(() => getCalendarMonthDates(today), [today]);
   const weekDates = useMemo(() => getCalendarWeekDates(today), [today]);
   const dates = isMonthly ? monthDates : weekDates;

--- a/src/app/(shared)/(standard)/daily/_components/Calendar/Calendar.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Calendar/Calendar.tsx
@@ -2,22 +2,27 @@
 
 import dayjs from 'dayjs';
 import { useRouter } from 'next/navigation';
-import { useState, useMemo } from 'react';
+import { useEffect, useRef, useState, useMemo } from 'react';
 
+import ArrowRight from '@/assets/icons/arrowright.svg';
 import ChevronDown from '@/assets/icons/chevrondown.svg';
 import ChevronUp from '@/assets/icons/chevronup.svg';
 import SolidButton from '@/components/atoms/SolidButton/SolidButton';
 import { WEEK_DAYS } from '@/constants/common';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { getCalendarMonthDates, getCalendarWeekDates } from '@/utils/getCalendar';
 
 import * as S from './Calendar.styled';
 import DateCell from './DateCell/DataCell';
+import FirstAnswerButton from './FirstAnswerButton/FirstAnswerButton';
 
 interface CalendarProps {
   streakDateList: string[];
+  hasAnswered: boolean;
 }
 
-export default function Calendar({ streakDateList }: CalendarProps) {
+export default function Calendar({ streakDateList, hasAnswered }: CalendarProps) {
+  const { isLoggedIn } = useAuthStore();
   const router = useRouter();
   const today = dayjs();
 
@@ -25,6 +30,24 @@ export default function Calendar({ streakDateList }: CalendarProps) {
   const monthDates = useMemo(() => getCalendarMonthDates(today), [today]);
   const weekDates = useMemo(() => getCalendarWeekDates(today), [today]);
   const dates = isMonthly ? monthDates : weekDates;
+
+  const [isFirstAnswer, setIsFirstAnswer] = useState(false);
+  const prevHasAnsweredRef = useRef<boolean>(hasAnswered);
+
+  const handleGoToReport = () => {
+    if (!isLoggedIn) {
+      router.push('/login');
+      return;
+    }
+    router.push('/mypage/activity');
+  };
+
+  useEffect(() => {
+    if (!prevHasAnsweredRef.current && hasAnswered) {
+      setIsFirstAnswer(true);
+    }
+    prevHasAnsweredRef.current = hasAnswered;
+  }, [hasAnswered]);
 
   return (
     <S.CalendarCard>
@@ -50,15 +73,19 @@ export default function Calendar({ streakDateList }: CalendarProps) {
             ))}
           </S.Grid>
         </S.CalendarWrapper>
-        <SolidButton
-          label='리포트 보러가기'
-          size='md'
-          interactionVariant='normal'
-          onClick={() => {
-            router.push('/mypage/activity');
-          }}
-          fillContainer
-        />
+        {isFirstAnswer ? (
+          <FirstAnswerButton onClick={handleGoToReport} />
+        ) : (
+          <SolidButton
+            label='리포트 보러가기'
+            size='md'
+            interactionVariant='normal'
+            onClick={handleGoToReport}
+            fillContainer
+            align='center'
+            iconRight={<ArrowRight />}
+          />
+        )}
       </S.CalendarContentWrapper>
     </S.CalendarCard>
   );

--- a/src/app/(shared)/(standard)/daily/_components/Calendar/FirstAnswerButton/FirstAnswerButton.styled.ts
+++ b/src/app/(shared)/(standard)/daily/_components/Calendar/FirstAnswerButton/FirstAnswerButton.styled.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { getInteraction } from '@/styles/interaction';
+
+const gradientSlide = keyframes`
+  0% {
+    background-position: 200% 0%;
+  }
+  100% {
+    background-position: 0% 0%;
+  }
+`;
+
+export const ButtonWrapper = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+
+  width: 100%;
+
+  padding: 1.1rem 2.3rem;
+  border-radius: ${({ theme }) => theme.radius[12]};
+  border: 1px solid ${({ theme }) => theme.semantic.primary.normal};
+  background-color: ${({ theme }) => theme.semantic.static.white};
+  color: ${({ theme }) => theme.semantic.primary.normal};
+  ${({ theme }) => theme.typography.body2.semibold};
+  border-bottom: 6px solid ${({ theme }) => theme.semantic.primary.normal};
+
+  background-image: linear-gradient(90deg, #ffffff 0%, #e4f8ff 30%, #ffffff 60%, #e4f8ff 90%, #ffffff 100%);
+  background-size: 200% 100%;
+  animation: ${gradientSlide} 2.5s ease-in-out infinite;
+
+  ${({ theme }) => getInteraction('normal', theme.semantic.label.normal, false)(theme)};
+
+  &:focus {
+    outline: none;
+  }
+
+  &:disabled {
+    border-color: ${({ theme }) => theme.semantic.label.assistive};
+    color: ${({ theme }) => theme.semantic.label.assistive};
+    cursor: default;
+    pointer-events: none;
+  }
+`;
+
+export const Icon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  & > svg {
+    width: 1.2em;
+    height: 1.2em;
+  }
+`;

--- a/src/app/(shared)/(standard)/daily/_components/Calendar/FirstAnswerButton/FirstAnswerButton.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Calendar/FirstAnswerButton/FirstAnswerButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import ArrowRight from '@/assets/icons/arrowright.svg';
+
+import * as S from './FirstAnswerButton.styled';
+
+interface FirstAnswerButtonProps {
+  onClick?: () => void;
+}
+
+export default function FirstAnswerButton({ onClick }: FirstAnswerButtonProps) {
+  return (
+    <S.ButtonWrapper onClick={onClick}>
+      리포트 보러가기
+      <S.Icon>
+        <ArrowRight />
+      </S.Icon>
+    </S.ButtonWrapper>
+  );
+}

--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
@@ -17,11 +17,13 @@ interface QuestionProps {
   assignedQuestionId: number;
   question: string;
   answer?: string;
+  hasAnswered: boolean;
 }
 
-export default function Question({ assignedQuestionId, question, answer }: QuestionProps) {
-  const [inputValue, setInputValue] = useState('');
-  const [isAnswered, setIsAnswered] = useState(false);
+export default function Question({ assignedQuestionId, question, answer, hasAnswered }: QuestionProps) {
+  const [inputValue, setInputValue] = useState(answer ?? '');
+  const [isAnswered, setIsAnswered] = useState<boolean>(answer ? true : false);
+  const isFirstAnswer = useRef<boolean>(hasAnswered);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -43,11 +45,20 @@ export default function Question({ assignedQuestionId, question, answer }: Quest
       open('login', undefined);
       return;
     }
+
     submitDailyAnswer({ assignedQuestionId, answer: inputValue });
   };
 
   const handleEdit = () => {
     editDailyAnswer({ assignedQuestionId, answer: inputValue });
+  };
+
+  const handleFocus = () => {
+    if (!isFirstAnswer.current && isLoggedIn) {
+      open('dailyFirstAnswer', undefined);
+      isFirstAnswer.current = true;
+      return;
+    }
   };
 
   useEffect(() => {
@@ -87,6 +98,7 @@ export default function Question({ assignedQuestionId, question, answer }: Quest
             onChange={(e) => {
               setInputValue(e.target.value);
             }}
+            onFocus={handleFocus}
           />
         </S.InputGroup>
         <TextButton

--- a/src/app/(shared)/(standard)/daily/_components/Streak/Streak.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Streak/Streak.tsx
@@ -7,10 +7,10 @@ import { formatDayAsSlashYYMMDD } from '@/utils/formatDay';
 import * as S from './Streak.styled';
 
 interface StreakProps {
-  streaksDays: number;
+  dailyStreak: number;
 }
 
-export default function Streak({ streaksDays }: StreakProps) {
+export default function Streak({ dailyStreak }: StreakProps) {
   const today = dayjs();
 
   return (
@@ -23,11 +23,11 @@ export default function Streak({ streaksDays }: StreakProps) {
             width={11}
             height={14}
           />
-          <p>{streaksDays}</p>
+          <p>{dailyStreak}</p>
         </S.CountWrapper>
         <S.MessageWrapper>
           <S.MessageContinue>연속</S.MessageContinue>
-          <S.MessageDate>{streaksDays}일째</S.MessageDate>
+          <S.MessageDate>{dailyStreak}일째</S.MessageDate>
           <S.Message>꾸준히 하고 계시네요, 앞으로도 저희와 함께 해요!</S.Message>
         </S.MessageWrapper>
 

--- a/src/app/(shared)/(standard)/daily/page.tsx
+++ b/src/app/(shared)/(standard)/daily/page.tsx
@@ -28,7 +28,10 @@ export default function Daily() {
             answer={dailyData?.result.answer ?? ''}
             hasAnswered={hasAnsweredData?.result.hasAnswered ?? false}
           />
-          <Calendar streakDateList={streakCalendarData?.result.streakDateList ?? []} />
+          <Calendar
+            streakDateList={streakCalendarData?.result.streakDateList ?? []}
+            hasAnswered={hasAnsweredData?.result.hasAnswered ?? false}
+          />
         </>
       )}
     </S.DailyContainer>

--- a/src/app/(shared)/(standard)/daily/page.tsx
+++ b/src/app/(shared)/(standard)/daily/page.tsx
@@ -2,6 +2,8 @@
 
 import { DEFAULT_DAILY_QUESTION } from '@/constants/common';
 import useGetDailyQuery from '@/hooks/api/daily/useGetDaily';
+import useGetDailyHasAnsweredQuery from '@/hooks/api/daily/useGetDailyHasAnswered';
+import useGetStreakCalendarQuery from '@/hooks/api/streak/useGetStreakCalendar';
 import useGetStreakDaysQuery from '@/hooks/api/streak/useGetStreakDays';
 
 import Calendar from './_components/Calendar/Calendar';
@@ -11,19 +13,22 @@ import * as S from './page.styled';
 
 export default function Daily() {
   const { data: dailyData, isLoading } = useGetDailyQuery();
-  const { data: streakData } = useGetStreakDaysQuery();
+  const { data: streakCalendarData } = useGetStreakCalendarQuery();
+  const { data: streakDaysData } = useGetStreakDaysQuery();
+  const { data: hasAnsweredData } = useGetDailyHasAnsweredQuery();
 
   return (
     <S.DailyContainer>
       {!isLoading && (
         <>
-          <Streak streaksDays={streakData?.result.dailyStreak ?? 0} />
+          <Streak dailyStreak={streakDaysData?.result.dailyStreak ?? 0} />
           <Question
             assignedQuestionId={dailyData?.result.assignedQuestionId ?? 0}
             question={dailyData?.result.question ?? DEFAULT_DAILY_QUESTION}
             answer={dailyData?.result.answer ?? ''}
+            hasAnswered={hasAnsweredData?.result.hasAnswered ?? false}
           />
-          <Calendar streakDateList={streakData?.result.streakDateList ?? []} />
+          <Calendar streakDateList={streakCalendarData?.result.streakDateList ?? []} />
         </>
       )}
     </S.DailyContainer>

--- a/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
@@ -49,6 +49,7 @@ export default function DailyQuestionCard({
           iconRight={isOpen ? <ChevronUp /> : <ChevronDown />}
           interactionVariant='normal'
           fillContainer
+          
           onClick={toggleOpen}
         />
         {isOpen && (

--- a/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
+++ b/src/app/(shared)/(standard)/mypage/activity/daily/_components/DailyQuestionCard/DailyQuestionCard.tsx
@@ -49,7 +49,6 @@ export default function DailyQuestionCard({
           iconRight={isOpen ? <ChevronUp /> : <ChevronDown />}
           interactionVariant='normal'
           fillContainer
-          
           onClick={toggleOpen}
         />
         {isOpen && (

--- a/src/components/atoms/OutlinedButton/OutlinedButton.stories.tsx
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.stories.tsx
@@ -37,8 +37,9 @@ const meta = {
     iconRight: {
       table: { disable: true },
     },
-    hasIcon: {
-      table: { disable: true },
+    align: {
+      control: 'radio',
+      options: ['center', 'space-between'],
     },
   },
 } satisfies Meta<typeof OutlinedButton>;
@@ -55,6 +56,7 @@ export const NoIcon: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -68,6 +70,7 @@ export const LeftIconOnly: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -81,6 +84,7 @@ export const RightIconOnly: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -95,6 +99,7 @@ export const LeftRightIcon: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -109,5 +114,6 @@ export const FillContainerWithIcons: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'space-between',
   },
 };

--- a/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
@@ -12,14 +12,14 @@ export interface OutlinedButtonStyleProps {
   color: OutlinedButtonColor;
   size: OutlinedButtonSize;
   fillContainer?: boolean;
-  hasIcon?: boolean;
   interactionVariant: InteractionVariant;
+  align?: 'center' | 'space-between';
 }
 
-const commonStyles = (theme: Theme, fillContainer?: boolean, hasIcon?: boolean) => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, align?: 'center' | 'space-between') => css`
   display: flex;
   align-items: center;
-  justify-content: ${fillContainer && hasIcon ? 'space-between' : 'center'};
+  justify-content: ${align};
   gap: 4px;
 
   width: ${fillContainer ? '100%' : 'auto'};
@@ -81,7 +81,7 @@ const getInteractionColor = (theme: Theme, color: OutlinedButtonColor) => {
 };
 
 export const OutlinedButton = styled.button<OutlinedButtonStyleProps>`
-  ${({ theme, fillContainer, hasIcon }) => commonStyles(theme, fillContainer, hasIcon)};
+  ${({ theme, fillContainer, align }) => commonStyles(theme, fillContainer, align)};
   ${({ theme, size }) => sizeStyles[size](theme)};
   ${({ theme, color }) => colorStyles[color](theme)};
   ${({ theme, interactionVariant, disabled, color }) =>

--- a/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.styled.ts
@@ -7,16 +7,17 @@ import { getInteraction, InteractionVariant } from '@/styles/interaction';
 
 type OutlinedButtonColor = 'primary' | 'secondary' | 'assistive';
 type OutlinedButtonSize = 'sm' | 'md' | 'lg';
+type OutlinedButtonAlign = 'center' | 'space-between';
 
 export interface OutlinedButtonStyleProps {
   color: OutlinedButtonColor;
   size: OutlinedButtonSize;
   fillContainer?: boolean;
   interactionVariant: InteractionVariant;
-  align?: 'center' | 'space-between';
+  align?: OutlinedButtonAlign;
 }
 
-const commonStyles = (theme: Theme, fillContainer?: boolean, align?: 'center' | 'space-between') => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, align?: OutlinedButtonAlign) => css`
   display: flex;
   align-items: center;
   justify-content: ${align};

--- a/src/components/atoms/OutlinedButton/OutlinedButton.tsx
+++ b/src/components/atoms/OutlinedButton/OutlinedButton.tsx
@@ -21,17 +21,18 @@ export default function OutlinedButton({
   onClick,
   interactionVariant,
   type = 'button',
+  align = 'space-between',
 }: OutlinedButtonProps) {
   return (
     <S.OutlinedButton
       size={size}
       color={color}
       fillContainer={fillContainer}
-      hasIcon={!!iconLeft || !!iconRight}
       disabled={isDisabled}
       onClick={onClick}
       interactionVariant={interactionVariant}
       type={type}
+      align={align}
     >
       {iconLeft && <S.Icon>{iconLeft}</S.Icon>}
       {label}

--- a/src/components/atoms/SolidButton/SolidButton.stories.tsx
+++ b/src/components/atoms/SolidButton/SolidButton.stories.tsx
@@ -123,4 +123,3 @@ export const FillContainerWithIcons: Story = {
     align: 'space-between',
   },
 };
-

--- a/src/components/atoms/SolidButton/SolidButton.stories.tsx
+++ b/src/components/atoms/SolidButton/SolidButton.stories.tsx
@@ -38,6 +38,10 @@ const meta = {
         disable: true,
       },
     },
+    align: {
+      control: 'radio',
+      options: ['center', 'space-between'],
+    },
   },
 } satisfies Meta<typeof SolidButton>;
 
@@ -51,6 +55,7 @@ export const NoIcon: Story = {
     isDisabled: false,
     interactionVariant: 'strong',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -62,6 +67,7 @@ export const LeftIconOnly: Story = {
     isDisabled: false,
     interactionVariant: 'strong',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -73,6 +79,7 @@ export const RightIconOnly: Story = {
     isDisabled: false,
     interactionVariant: 'strong',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -85,6 +92,7 @@ export const Primary: Story = {
     isDisabled: false,
     interactionVariant: 'strong',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
 
@@ -98,5 +106,21 @@ export const Kakao: Story = {
     isDisabled: false,
     interactionVariant: 'normal',
     onClick: action('clicked'),
+    align: 'center',
   },
 };
+
+export const FillContainerWithIcons: Story = {
+  args: {
+    label: 'Full Width',
+    iconLeft: <Blank />,
+    iconRight: <Blank />,
+    size: 'lg',
+    fillContainer: true,
+    isDisabled: false,
+    interactionVariant: 'normal',
+    onClick: action('clicked'),
+    align: 'space-between',
+  },
+};
+

--- a/src/components/atoms/SolidButton/SolidButton.styled.ts
+++ b/src/components/atoms/SolidButton/SolidButton.styled.ts
@@ -16,13 +16,13 @@ export interface SolidButtonStyleProps {
   size: SolidButtonSize;
   interactionVariant: InteractionVariant;
   fillContainer?: boolean;
-  hasIcon?: boolean;
+  align?: 'center' | 'space-between';
 }
 
-const commonStyles = (theme: Theme, fillContainer?: boolean, hasIcon?: boolean) => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, align?: 'center' | 'space-between') => css`
   display: flex;
   align-items: center;
-  justify-content: ${fillContainer && hasIcon ? 'space-between' : 'center'};
+  justify-content: ${align};
   gap: 4px;
 
   width: ${fillContainer ? '100%' : 'auto'};
@@ -72,7 +72,7 @@ const colorStyles: Record<SolidButtonColor, (theme: Theme) => SerializedStyles> 
 };
 
 export const StyledSolidButton = styled.button<SolidButtonStyleProps>`
-  ${({ theme, fillContainer, hasIcon }) => commonStyles(theme, fillContainer, hasIcon)};
+  ${({ theme, fillContainer, align }) => commonStyles(theme, fillContainer, align)};
   ${({ theme, size }) => sizeStyles[size](theme)};
   ${({ theme, color }) => (color ? colorStyles[color](theme) : colorStyles.primary(theme))};
   ${({ theme, interactionVariant, disabled }) =>

--- a/src/components/atoms/SolidButton/SolidButton.styled.ts
+++ b/src/components/atoms/SolidButton/SolidButton.styled.ts
@@ -10,16 +10,17 @@ type BrandColors = keyof typeof brandColors;
 
 type SolidButtonColor = 'primary' | BrandColors;
 type SolidButtonSize = 'sm' | 'md' | 'lg';
+type SolidButtonAlign = 'center' | 'space-between';
 
 export interface SolidButtonStyleProps {
   color?: SolidButtonColor;
   size: SolidButtonSize;
   interactionVariant: InteractionVariant;
   fillContainer?: boolean;
-  align?: 'center' | 'space-between';
+  align?: SolidButtonAlign;
 }
 
-const commonStyles = (theme: Theme, fillContainer?: boolean, align?: 'center' | 'space-between') => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, align?: SolidButtonAlign) => css`
   display: flex;
   align-items: center;
   justify-content: ${align};

--- a/src/components/atoms/SolidButton/SolidButton.tsx
+++ b/src/components/atoms/SolidButton/SolidButton.tsx
@@ -21,6 +21,7 @@ export default function SolidButton({
   onClick,
   interactionVariant,
   type = 'button',
+  align = 'space-between',
 }: SolidButtonProps) {
   return (
     <S.StyledSolidButton
@@ -31,10 +32,11 @@ export default function SolidButton({
       interactionVariant={interactionVariant}
       fillContainer={fillContainer}
       type={type}
+      align={align}
     >
-      <S.Icon>{iconLeft}</S.Icon>
+      {iconLeft && <S.Icon>{iconLeft}</S.Icon>}
       {label}
-      <S.Icon>{iconRight}</S.Icon>
+      {iconRight && <S.Icon>{iconRight}</S.Icon>}
     </S.StyledSolidButton>
   );
 }

--- a/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.styled.ts
+++ b/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.styled.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: relative;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing[32]};
+
+  width: 40.7rem;
+  height: 25rem;
+  padding: ${({ theme }) => theme.spacing[12]} ${({ theme }) => theme.spacing[24]};
+  background-color: ${({ theme }) => theme.semantic.background.normal.normal};
+  border-radius: ${({ theme }) => theme.radius[8]};
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing[16]};
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.body2.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;

--- a/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.tsx
+++ b/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import { useModalStore } from '@/stores/useModalStore';
+
+import * as S from './DailyFirstAnswer.styled';
+
+export default function DailyFirstAnswer() {
+  const { close } = useModalStore();
+
+  const handleClick = () => {
+    close();
+  };
+
+  return (
+    <S.Container>
+      <S.TextWrapper>
+        <S.Title>작성한 답변은 오늘 자정까지만 바꿀 수 있어요</S.Title>
+      </S.TextWrapper>
+
+      <OutlinedButton
+        label='확인했어요'
+        size='sm'
+        color='assistive'
+        interactionVariant='normal'
+        onClick={handleClick}
+        type='submit'
+      />
+    </S.Container>
+  );
+}

--- a/src/components/organisms/Modal/Login/Login.tsx
+++ b/src/components/organisms/Modal/Login/Login.tsx
@@ -49,6 +49,7 @@ export default function Login() {
         interactionVariant='normal'
         iconLeft={<Kakao />}
         onClick={handleClick}
+        align='center'
         fillContainer
       />
     </S.Container>

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -2,6 +2,7 @@ import type { ModalMap } from '@/types/modal';
 
 import DailyAnswerEdit from './Daily/Edit/DailyAnswerEdit';
 import DailyAnswerPost, { DailyProps } from './Daily/Post/DailyAnswerPost';
+import DailyFirstAnswer from './Daily/FirstAnswer/DailyFirstAnswer';
 import Login from './Login/Login';
 import Logout from './Logout/Logout';
 import Signup, { SignupProps } from './Signup/Signup';
@@ -11,7 +12,8 @@ export type AppModalProps = {
   signup: SignupProps;
   logout: undefined;
   dailyAnswerPost: DailyProps;
-  dailyAnswerEdit: undefined;
+  dailyAnswerEdit: DailyProps;
+  dailyFirstAnswer: undefined;
 };
 
 export const modalRegistry: ModalMap<AppModalProps> = {
@@ -33,6 +35,10 @@ export const modalRegistry: ModalMap<AppModalProps> = {
   },
   dailyAnswerEdit: {
     Component: DailyAnswerEdit,
+    disableOutsideClick: false,
+  },
+  dailyFirstAnswer: {
+    Component: DailyFirstAnswer,
     disableOutsideClick: false,
   },
 };

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,8 +1,8 @@
 import type { ModalMap } from '@/types/modal';
 
 import DailyAnswerEdit from './Daily/Edit/DailyAnswerEdit';
-import DailyAnswerPost, { DailyProps } from './Daily/Post/DailyAnswerPost';
 import DailyFirstAnswer from './Daily/FirstAnswer/DailyFirstAnswer';
+import DailyAnswerPost, { DailyProps } from './Daily/Post/DailyAnswerPost';
 import Login from './Login/Login';
 import Logout from './Logout/Logout';
 import Signup, { SignupProps } from './Signup/Signup';

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -41,6 +41,7 @@ export const END_POINTS_V1 = {
     ANSWERS: `${BASE_PATH_V1.DAILY}/answers`,
     ANSWERS_EDIT: (answerId: string) => `${BASE_PATH_V1.DAILY}/answers/${answerId}`,
     CALENDAR: `${BASE_PATH_V1.DAILY}/calendar`,
+    HAS_ANSWERED: `${BASE_PATH_V1.DAILY}/has-answered`,
   },
   CONTENTS: {
     CONTENTS: BASE_PATH_V1.CONTENTS,
@@ -56,6 +57,7 @@ export const END_POINTS_V1 = {
   },
   STREAKS: {
     CALENDAR: `${BASE_PATH_V1.STREAKS}/calendar`,
+    DAILY_STREAK: `${BASE_PATH_V1.STREAKS}/daily-streak`,
   },
 
   ADMIN: {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -12,11 +12,13 @@ const MEMBER_QUERY_KEYS = {
 } as const;
 
 const DAILY_QUERY_KEYS = {
-  DAILY: ['streak', 'question', 'answer'],
+  DAILY: ['daily', 'question', 'answer'],
+  DAILY_HAS_ANSWERED: ['daily', 'hasAnswered'],
 } as const;
 
 const STREAK_QUERY_KEYS = {
-  STREAK_DAYS: 'streak_days',
+  STREAK_DAYS: ['streak', 'days'],
+  STREAK_CALENDAR: ['streak', 'calendar'],
 } as const;
 
 const ADMIN_QUERY_KEYS = {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -17,8 +17,8 @@ const DAILY_QUERY_KEYS = {
 } as const;
 
 const STREAK_QUERY_KEYS = {
-  STREAK_DAYS: ['streak', 'days'],
   STREAK_CALENDAR: ['streak', 'calendar'],
+  STREAK_DAYS: ['streak', 'days'],
 } as const;
 
 const ADMIN_QUERY_KEYS = {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -12,11 +12,13 @@ const MEMBER_QUERY_KEYS = {
 } as const;
 
 const DAILY_QUERY_KEYS = {
-  DAILY: ['daily', 'question', 'answer'],
+  DAILY: ['daily'],
+  DAILY_QUESTION_ANSWER: ['daily', 'question', 'answer'],
   DAILY_HAS_ANSWERED: ['daily', 'hasAnswered'],
 } as const;
 
 const STREAK_QUERY_KEYS = {
+  STREAK: ['streak'],
   STREAK_CALENDAR: ['streak', 'calendar'],
   STREAK_DAYS: ['streak', 'days'],
 } as const;

--- a/src/hooks/api/daily/useEditDailyAnswer.ts
+++ b/src/hooks/api/daily/useEditDailyAnswer.ts
@@ -1,18 +1,21 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { dailyApi } from '@/api/dailyApis';
+import { DAILY_QUERY_KEYS } from '@/constants/queryKeys';
 import { useModalStore } from '@/stores/useModalStore';
 
 // 답변 수정
 export const useEditDailyAnswerMutation = () => {
+  const queryClient = useQueryClient();
   const { open } = useModalStore();
 
   const mutation = useMutation({
     mutationFn: dailyApi.editDailyAnswer,
     onSuccess: () => {
-      open('dailyAnswerEdit', undefined);
+      open('dailyAnswerEdit', { redirectTo: '/daily' });
+      queryClient.invalidateQueries({ queryKey: [...DAILY_QUERY_KEYS.DAILY] });
     },
     onError: () => {
       // FIXME: 모달로 변경

--- a/src/hooks/api/daily/useGetDailyHasAnswered.ts
+++ b/src/hooks/api/daily/useGetDailyHasAnswered.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { dailyApi } from '@/api/dailyApis';
+import { DAILY_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+export default function useGetDailyHasAnsweredQuery() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
+  return useQuery({
+    queryKey: [...DAILY_QUERY_KEYS.DAILY_HAS_ANSWERED],
+    queryFn: dailyApi.getDailyHasAnswered,
+    enabled: isLoggedIn,
+  });
+}

--- a/src/hooks/api/daily/useSubmitDailyAnswer.ts
+++ b/src/hooks/api/daily/useSubmitDailyAnswer.ts
@@ -1,19 +1,25 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { dailyApi } from '@/api/dailyApis';
+import { DAILY_QUERY_KEYS, STREAK_QUERY_KEYS } from '@/constants/queryKeys';
 import { useModalStore } from '@/stores/useModalStore';
 
 // 답변 제출
 export const useSubmitDailyAnswerMutation = () => {
+  const queryClient = useQueryClient();
+
   const { open } = useModalStore();
+
   const mutation = useMutation({
     mutationFn: dailyApi.submitDailyAnswer,
     onSuccess: () => {
       open('dailyAnswerPost', { redirectTo: '/daily' });
+      queryClient.invalidateQueries({ queryKey: [...DAILY_QUERY_KEYS.DAILY] });
+      queryClient.invalidateQueries({ queryKey: [...STREAK_QUERY_KEYS.STREAK] });
     },
-    onError: () => {
+    onError: (error) => {
       // FIXME: 모달로 변경
       alert('답변 제출에 실패했습니다. 잠시 후 다시 시도해주세요.');
     },

--- a/src/hooks/api/streak/useGetStreakCalendar.ts
+++ b/src/hooks/api/streak/useGetStreakCalendar.ts
@@ -4,12 +4,12 @@ import { streakApi } from '@/api/streakApis';
 import { STREAK_QUERY_KEYS } from '@/constants/queryKeys';
 import { useAuthStore } from '@/stores/useAuthStore';
 
-export default function useGetStreakDaysQuery() {
+export default function useGetStreakCalendarQuery() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   return useQuery({
     queryKey: [...STREAK_QUERY_KEYS.STREAK_CALENDAR],
-    queryFn: streakApi.getStreakDays,
+    queryFn: streakApi.getStreakCalendar,
     enabled: isLoggedIn,
   });
 }

--- a/src/hooks/api/streak/useGetStreakDays.ts
+++ b/src/hooks/api/streak/useGetStreakDays.ts
@@ -8,7 +8,7 @@ export default function useGetStreakDaysQuery() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   return useQuery({
-    queryKey: [...STREAK_QUERY_KEYS.STREAK_CALENDAR],
+    queryKey: [...STREAK_QUERY_KEYS.STREAK_DAYS],
     queryFn: streakApi.getStreakDays,
     enabled: isLoggedIn,
   });

--- a/src/mocks/data/daily/getDailyHasAnswered.ts
+++ b/src/mocks/data/daily/getDailyHasAnswered.ts
@@ -1,0 +1,15 @@
+export const getDailyHasAnswered_NotAnswered = {
+  code: 'SUCCESS',
+  message: '데일리 질문 조회(답변 전)에 성공했습니다.',
+  result: {
+    hasAnswered: false,
+  },
+};
+
+export const getDailyHasAnswered_Answered = {
+  code: 'SUCCESS',
+  message: '데일리 질문 조회(답변 후)에 성공했습니다.',
+  result: {
+    hasAnswered: true,
+  },
+};

--- a/src/mocks/data/streak/getStreakCalendarData.ts
+++ b/src/mocks/data/streak/getStreakCalendarData.ts
@@ -1,0 +1,7 @@
+export const getStreakCalendarSuccess = {
+  code: 'SUCCESS',
+  message: '스트릭 캘린더 조회에 성공했습니다.',
+  result: {
+    streakDateList: ['2025-06-10', '2025-06-06', '2025-06-05', '2025-06-04', '2025-06-03', '2025-05-31', '2025-05-26'],
+  },
+};

--- a/src/mocks/data/streak/getStreakDaysData.ts
+++ b/src/mocks/data/streak/getStreakDaysData.ts
@@ -1,8 +1,7 @@
 export const getStreakDaysSuccess = {
   code: 'SUCCESS',
-  message: '스트릭 캘린더 조회에 성공했습니다.',
+  message: '스트릭 일수 조회에 성공했습니다.',
   result: {
-    dailyStreak: 10,
-    streakDateList: ['2025-06-10', '2025-06-06', '2025-06-05', '2025-06-04', '2025-06-03', '2025-05-31', '2025-05-26'],
+    streakDays: 10,
   },
 };

--- a/src/mocks/data/streak/getStreakDaysData.ts
+++ b/src/mocks/data/streak/getStreakDaysData.ts
@@ -2,6 +2,6 @@ export const getStreakDaysSuccess = {
   code: 'SUCCESS',
   message: '스트릭 일수 조회에 성공했습니다.',
   result: {
-    streakDays: 10,
+    dailyStreak: 10,
   },
 };

--- a/src/mocks/handlers/daily.ts
+++ b/src/mocks/handlers/daily.ts
@@ -14,12 +14,20 @@ import {
   submitDailyAnswerError_EmptyField,
   submitDailyAnswerError_LengthExceeded,
 } from '../data/daily/submitDailyAnswer';
+import { getDailyHasAnswered_NotAnswered, getDailyHasAnswered_Answered } from '../data/daily/getDailyHasAnswered';
 
 export const dailyHandlers = [
   // 질문 및 스트릭 정보 조회
   http.get(END_POINTS_V1.DAILY.QUESTIONS, async () => {
     // 답변 후 dailyDataAnswered, 답변 전 dailyDataNotAnswered
     return new HttpResponse(JSON.stringify(getDailySuccess_NotAnswered), {
+      status: HTTP_STATUS_CODE.OK,
+    });
+  }),
+
+  // 답변 여부 조회 (답변 전)
+  http.get(END_POINTS_V1.DAILY.HAS_ANSWERED, async () => {
+    return new HttpResponse(JSON.stringify(getDailyHasAnswered_Answered), {
       status: HTTP_STATUS_CODE.OK,
     });
   }),

--- a/src/mocks/handlers/daily.ts
+++ b/src/mocks/handlers/daily.ts
@@ -9,12 +9,12 @@ import {
   editDailyAnswerError_LengthExceeded,
 } from '../data/daily/editDailyAnswer';
 import { getDailySuccess_NotAnswered, getDailySuccess_Answered } from '../data/daily/getDailyData';
+import { getDailyHasAnswered_NotAnswered, getDailyHasAnswered_Answered } from '../data/daily/getDailyHasAnswered';
 import {
   submitDailyAnswerSuccess,
   submitDailyAnswerError_EmptyField,
   submitDailyAnswerError_LengthExceeded,
 } from '../data/daily/submitDailyAnswer';
-import { getDailyHasAnswered_NotAnswered, getDailyHasAnswered_Answered } from '../data/daily/getDailyHasAnswered';
 
 export const dailyHandlers = [
   // 질문 및 스트릭 정보 조회
@@ -25,9 +25,9 @@ export const dailyHandlers = [
     });
   }),
 
-  // 답변 여부 조회 (답변 전)
+  // 첫 답변 여부 조회 (답변 전)
   http.get(END_POINTS_V1.DAILY.HAS_ANSWERED, async () => {
-    return new HttpResponse(JSON.stringify(getDailyHasAnswered_Answered), {
+    return new HttpResponse(JSON.stringify(getDailyHasAnswered_NotAnswered), {
       status: HTTP_STATUS_CODE.OK,
     });
   }),

--- a/src/mocks/handlers/streak.ts
+++ b/src/mocks/handlers/streak.ts
@@ -2,10 +2,17 @@ import { http, HttpResponse } from 'msw';
 
 import { END_POINTS_V1, HTTP_STATUS_CODE } from '@/constants/api';
 
+import { getStreakCalendarSuccess } from '../data/streak/getStreakCalendarData';
 import { getStreakDaysSuccess } from '../data/streak/getStreakDaysData';
 
 export const streakHandlers = [
   http.get(END_POINTS_V1.STREAKS.CALENDAR, async () => {
+    return new HttpResponse(JSON.stringify(getStreakCalendarSuccess), {
+      status: HTTP_STATUS_CODE.OK,
+    });
+  }),
+
+  http.get(END_POINTS_V1.STREAKS.DAILY_STREAK, async () => {
     return new HttpResponse(JSON.stringify(getStreakDaysSuccess), {
       status: HTTP_STATUS_CODE.OK,
     });

--- a/src/types/daily.ts
+++ b/src/types/daily.ts
@@ -24,3 +24,9 @@ export interface DailyContent {
   categories: string[];
   answeredAt?: string;
 }
+
+export interface DailyHasAnsweredResponse extends ApiResponse {
+  result: {
+    hasAnswered: boolean;
+  };
+}

--- a/src/types/streak.ts
+++ b/src/types/streak.ts
@@ -1,8 +1,13 @@
 import { ApiResponse } from '@/types/api';
 
-export interface StreakDateListResponse extends ApiResponse {
+export interface StreakCalendarResponse extends ApiResponse {
   result: {
-    dailyStreak: number;
     streakDateList: string[];
+  };
+}
+
+export interface StreakDaysResponse extends ApiResponse {
+  result: {
+    streakDays: number;
   };
 }

--- a/src/types/streak.ts
+++ b/src/types/streak.ts
@@ -8,6 +8,6 @@ export interface StreakCalendarResponse extends ApiResponse {
 
 export interface StreakDaysResponse extends ApiResponse {
   result: {
-    streakDays: number;
+    dailyStreak: number;
   };
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #142 
- Closes #119  

## 📋 작업 내용

- 비회원 일 때 리포트 보러가기 로그인 모달로 연결

- 답변 최초 입력 시 모달 띄우기

- 백엔드 데이터 api 수정 사항 반영

- querykey 수정
query key invalidate를 하는데 daily 관련 데이터, streak 관련 데이터를 한번에 무효화 할 수 있게 따로 그 도메인만의 query key를 만들었습니다.

- 답변 최초 제출 시 버튼 강조
useRef 를 통해 값을 유지할 수 있는 방법이 있는 것 같더라구요. 테스트를 많이 못해 보는게 아쉽긴한데, 한번 해봤을때 강조가 되는 것을 확인 했습니다. 

https://github.com/user-attachments/assets/877badff-a07d-43ec-90a0-6d3da8db4378

효과가 맞는지는 모르겠지만... 넵 한번 이것도 확인부탁드릴게요. 이런 효과를 줘본적이 없어서 좀 서투르네요ㅜㅜ

- solid & outline button align 속성 추가
정렬을 center 속성도 필요한 순간이 있더라구요. 그래서 hasicon + fillcontainer 조합에서 아예 분리를 해서 align 값으로 정렬 방식을 정하도록 했습니다.

## 🛠️ 특이 사항


## ⚡️ 리뷰 요구사항 (선택)

일단 hasicon + fillcontainer 를 사용하는 컴포넌트를 찾아서 변경하긴 했는데 다 했는지는 확인이 불가능해서 한번 검토 해봐주시면 감사하겠습니다.
