### PR TITLE
[FIX] daily edit handler #172

### DIFF
--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
@@ -26,7 +26,6 @@ export default function Question({ assignedQuestionId, question, answer }: Quest
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { submitDailyAnswer } = useSubmitDailyAnswerMutation();
-  const { editDailyAnswer } = useEditDailyAnswerMutation();
   const { open } = useModalStore();
   const { isLoggedIn } = useAuthStore();
 
@@ -47,7 +46,7 @@ export default function Question({ assignedQuestionId, question, answer }: Quest
   };
 
   const handleEdit = () => {
-    editDailyAnswer({ assignedQuestionId, answer: inputValue });
+    open('dailyAnswerEdit', { assignedQuestionId, answer: inputValue, redirectTo: '/daily' });
   };
 
   useEffect(() => {

--- a/src/components/organisms/Modal/Daily/Edit/DailyAnswerEdit.tsx
+++ b/src/components/organisms/Modal/Daily/Edit/DailyAnswerEdit.tsx
@@ -4,15 +4,28 @@ import X from '@/assets/icons/x.svg';
 import IconButton from '@/components/atoms/IconButton/IconButton';
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
 import { useModalStore } from '@/stores/useModalStore';
+import { useEditDailyAnswerMutation } from '@/hooks/api/daily/useEditDailyAnswer';
+import { useRouter } from 'next/navigation';
 
 import * as S from './DailyAnswerEdit.styled';
 
-export default function DailyAnswerEdit() {
+export interface DailyAnswerEditProps {
+  assignedQuestionId: number;
+  answer: string;
+  redirectTo?: string;
+}
+
+export default function DailyAnswerEdit({ assignedQuestionId, answer, redirectTo }: DailyAnswerEditProps) {
+  const router = useRouter();
   const { close } = useModalStore();
+  const { editDailyAnswer } = useEditDailyAnswerMutation();
 
   const handleClick = () => {
+    editDailyAnswer({ assignedQuestionId, answer });
     close();
-    alert('수정되었습니다.');
+    if (redirectTo) {
+      router.push(redirectTo);
+    }
   };
 
   return (
@@ -22,7 +35,7 @@ export default function DailyAnswerEdit() {
           size='4rem'
           variant='normal'
           interactionVariant='normal'
-          onClick={handleClick}
+          onClick={close}
         >
           <X />
         </IconButton>

--- a/src/components/organisms/Modal/Daily/Post/DailyAnswerPost.tsx
+++ b/src/components/organisms/Modal/Daily/Post/DailyAnswerPost.tsx
@@ -9,11 +9,11 @@ import { useModalStore } from '@/stores/useModalStore';
 
 import * as S from './DailyAnswerPost.styled';
 
-export interface DailyProps {
+export interface DailyAnswerPostProps {
   redirectTo?: string;
 }
 
-export default function DailyAnswerPost({ redirectTo }: DailyProps) {
+export default function DailyAnswerPost({ redirectTo }: DailyAnswerPostProps) {
   const { close } = useModalStore();
   const router = useRouter();
 

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -1,7 +1,7 @@
 import type { ModalMap } from '@/types/modal';
 
-import DailyAnswerEdit from './Daily/Edit/DailyAnswerEdit';
-import DailyAnswerPost, { DailyProps } from './Daily/Post/DailyAnswerPost';
+import DailyAnswerEdit, { DailyAnswerEditProps } from './Daily/Edit/DailyAnswerEdit';
+import DailyAnswerPost, { DailyAnswerPostProps } from './Daily/Post/DailyAnswerPost';
 import Login from './Login/Login';
 import Logout from './Logout/Logout';
 import Signup, { SignupProps } from './Signup/Signup';
@@ -10,8 +10,8 @@ export type AppModalProps = {
   login: undefined;
   signup: SignupProps;
   logout: undefined;
-  dailyAnswerPost: DailyProps;
-  dailyAnswerEdit: undefined;
+  dailyAnswerPost: DailyAnswerPostProps;
+  dailyAnswerEdit: DailyAnswerEditProps;
 };
 
 export const modalRegistry: ModalMap<AppModalProps> = {

--- a/src/hooks/api/daily/useEditDailyAnswer.ts
+++ b/src/hooks/api/daily/useEditDailyAnswer.ts
@@ -3,16 +3,13 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { dailyApi } from '@/api/dailyApis';
-import { useModalStore } from '@/stores/useModalStore';
 
 // 답변 수정
 export const useEditDailyAnswerMutation = () => {
-  const { open } = useModalStore();
-
   const mutation = useMutation({
     mutationFn: dailyApi.editDailyAnswer,
     onSuccess: () => {
-      open('dailyAnswerEdit', undefined);
+      alert('수정되었습니다.');
     },
     onError: () => {
       // FIXME: 모달로 변경


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #172

## 📋 작업 내용

- 수정하기 플로우 변경
기존에 수정하기 버튼 -> 수정하기 모달 이런식으로 이루어져있는데 수정하기 버튼 에서 이미 수정이 되어버려 모달에서의 수정하기가 의미가 없었습니다. 테스트 해보니까 이걸 제가 놓쳤더라구요 .. 그래서 정상화 했습니다.

수정하기 버튼 -> 수정하기 모달에서 수정 api 활성화

- daily modalprops 네이밍 변경
DailyProps로 공통되게 했었는데 분리를 할 필요가 있어서 분리 했습니다.


## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
