### PR TITLE
[REFACTOR] 회원가입 플로우 수정 #133

### DIFF
--- a/src/components/organisms/Modal/Signup/Signup.tsx
+++ b/src/components/organisms/Modal/Signup/Signup.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { SIGNUP_STEP, SignupStep } from '@/constants/common';
+import { useSignupMutation } from '@/hooks/api/auth/useSignup';
 import { SignupFormFields } from '@/types/form';
 
 import { CheckEmail, InputEmail, VerifyEmail, Complete } from './Steps';
@@ -23,6 +24,12 @@ export default function Signup({ provider, providerId, email, nickname }: Signup
     reValidateMode: 'onBlur',
   });
 
+  const { signup } = useSignupMutation(() => setStep(SIGNUP_STEP.COMPLETE));
+
+  const handleVerifiedAndSignup = () => {
+    signup({ provider, providerId, email: methods.getValues('email'), nickname });
+  };
+
   return (
     <FormProvider {...methods}>
       {step === SIGNUP_STEP.CHECK_ORIGINAL_EMAIL && (
@@ -40,15 +47,9 @@ export default function Signup({ provider, providerId, email, nickname }: Signup
         />
       )}
 
-      {step === SIGNUP_STEP.VERIFY_EMAIL && <VerifyEmail onConfirm={() => setStep(SIGNUP_STEP.COMPLETE)} />}
+      {step === SIGNUP_STEP.VERIFY_EMAIL && <VerifyEmail onConfirm={handleVerifiedAndSignup} />}
 
-      {step === SIGNUP_STEP.COMPLETE && (
-        <Complete
-          provider={provider}
-          providerId={providerId}
-          nickname={nickname}
-        />
-      )}
+      {step === SIGNUP_STEP.COMPLETE && <Complete />}
     </FormProvider>
   );
 }

--- a/src/components/organisms/Modal/Signup/Steps/Complete/Complete.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/Complete/Complete.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import { useFormContext } from 'react-hook-form';
-
 import SolidButton from '@/components/atoms/SolidButton/SolidButton';
-import { useSignupMutation } from '@/hooks/api/auth/useSignup';
 import { useAppModalStore } from '@/stores/useModalStore';
 
 import * as S from './Complete.styled';
 
-export interface CompleteProps {
-  provider: string;
-  providerId: string;
-  nickname: string;
-}
-
-export default function Complete({ provider, providerId, nickname }: CompleteProps) {
-  const { signup } = useSignupMutation();
+export default function Complete() {
   const { close } = useAppModalStore();
-  const { getValues } = useFormContext<{ email: string }>();
-  const email = getValues('email');
-
-  const handleSignup = () => {
-    signup({ provider, providerId, email, nickname });
-    close();
-  };
 
   return (
     <>
@@ -44,7 +27,7 @@ export default function Complete({ provider, providerId, nickname }: CompletePro
         size='md'
         color='primary'
         interactionVariant='normal'
-        onClick={handleSignup}
+        onClick={close}
         fillContainer
       />
     </>

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -29,7 +29,7 @@ export type AlertModalProps = {
 
 export const AppModalRegistry = {
   login: { Component: Login, disableOutsideClick: false },
-  signup: { Component: Signup, disableOutsideClick: false },
+  signup: { Component: Signup, disableOutsideClick: true },
   logout: { Component: Logout, disableOutsideClick: false },
   dailyAnswerPost: { Component: DailyAnswerPost, disableOutsideClick: false },
   dailyAnswerEdit: { Component: DailyAnswerEdit, disableOutsideClick: false },

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -3,24 +3,23 @@ import { useRouter } from 'next/navigation';
 
 import { authApi } from '@/api/authApis';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useAlertModalStore } from '@/stores/useModalStore';
 
-export const useSignupMutation = () => {
+export const useSignupMutation = (onSuccess?: () => void) => {
   const router = useRouter();
+  const { open } = useAlertModalStore();
   const setToken = useAuthStore((state) => state.setToken);
 
   const mutation = useMutation({
     mutationFn: authApi.signup,
     onSuccess: (response) => {
       const accessToken = response.headers['authorization']?.replace(/^Bearer\s/i, '');
-
-      if (!!accessToken) {
-        setToken(accessToken);
-      }
-
+      if (accessToken) setToken(accessToken);
+      onSuccess?.();
       router.push('/');
     },
     onError: () => {
-      alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      open('error', { message: '회원가입에 실패했습니다.' });
       router.push('/');
     },
   });


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #133 

## 📋 작업 내용

- 회원가입 시 모달 바깥 클릭해도 꺼지지 않도록 disable으로 변경
- 회원가입 플로우 변경
-> 변경 전: COMPLETE 단계에서 "코그룸 살펴보기" 버튼을 클릭해야 회원가입이 수행됨
-> 변경 후: "인증 완료" 버튼 클릭 시 인증 확인 API 호출 → 인증 성공 시 즉시 회원가입 API 호출 → 회원가입 성공 시 COMPLETE 단계로 이동, 실패 시 에러 모달 표시

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
