### PR TITLE
[FEAT] 회원 탈퇴 구현 #206

### DIFF
--- a/src/api/authApis.ts
+++ b/src/api/authApis.ts
@@ -10,6 +10,7 @@ import {
   CheckEmailVerifiedRequest,
   SignupRequest,
   CheckEmailVerifiedResponse,
+  WithdrawRequest,
 } from '../types/auth';
 import { axiosInstance } from './axios/axiosInstance';
 
@@ -57,6 +58,17 @@ const logout = async () => {
   return data;
 };
 
+const withdraw = async ({ reason }: WithdrawRequest) => {
+  const { data } = await axiosInstance.delete<WithdrawRequest, AxiosResponse<ApiResponse>>(
+    END_POINTS_V1.AUTH.WITHDRAW,
+    {
+      data: { reason },
+    },
+  );
+
+  return data;
+};
+
 const reissueToken = async () => {
   const response = await axiosInstance.post<null, AxiosResponse>(END_POINTS_V1.AUTH.REISSUE_TOKEN, null, {
     useAuth: false,
@@ -72,5 +84,6 @@ export const authApi = {
   sendEmail,
   checkEmailVerified,
   logout,
+  withdraw,
   reissueToken,
 };

--- a/src/app/(shared)/(standard)/mypage/setting/page.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/setting/page.styled.ts
@@ -2,6 +2,15 @@
 
 import styled from '@emotion/styled';
 
+export const SettingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1.6rem;
+
+  width: 100%;
+`;
+
 export const SettingProfile = styled.div`
   position: relative;
 
@@ -19,7 +28,9 @@ export const SettingForm = styled.form`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: ${({ theme }) => theme.spacing[16]};
+  gap: 1.6rem;
+
+  width: 100%;
 `;
 
 export const ButtonWrapper = styled.div`

--- a/src/app/(shared)/(standard)/mypage/setting/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/page.tsx
@@ -3,13 +3,15 @@
 import { useEffect, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 
+import SettingIcon from '@/assets/icons/setting.svg';
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import TextButton from '@/components/atoms/TextButton/TextButton';
 import Input from '@/components/molecules/Input/Input';
 import Textarea from '@/components/molecules/Textarea/Textarea';
 import Loading from '@/components/organisms/Loading/Loading';
 import { useEditUserInfoMutation } from '@/hooks/api/member/useEditUserInfo';
 import useGetUserInfo from '@/hooks/api/member/useGetUserInfo';
-import { useAlertModalStore } from '@/stores/useModalStore';
+import { useAlertModalStore, useAppModalStore } from '@/stores/useModalStore';
 import { SettingFormFields } from '@/types/form';
 import { formatPhoneNumber } from '@/utils/formatAutoComplete';
 import { validatePhoneNumber } from '@/utils/validators/userValidators';
@@ -35,7 +37,8 @@ export default function Setting() {
   const [emailState, setEmailState] = useState<EmailState>('idle');
   const [isNicknameChecked, setIsNicknameChecked] = useState(true);
 
-  const { open } = useAlertModalStore();
+  const { open: openApp } = useAppModalStore();
+  const { open: openAlert } = useAlertModalStore();
   const { data, isLoading } = useGetUserInfo();
 
   const methods = useForm<SettingFormFields>({
@@ -63,7 +66,7 @@ export default function Setting() {
 
   const onSubmit = (formData: SettingFormFields) => {
     if (dirtyFields.nickname && !isNicknameChecked) {
-      open('alert', { message: '닉네임 중복 확인을 완료해주세요.' });
+      openAlert('alert', { message: '닉네임 중복 확인을 완료해주세요.' });
       return;
     }
 
@@ -73,51 +76,62 @@ export default function Setting() {
   if (isLoading) return <Loading />;
 
   return (
-    <FormProvider {...methods}>
-      <S.SettingForm onSubmit={handleSubmit(onSubmit)}>
-        <SettingProfile initialImageUrl={data?.imageUrl} />
+    <S.SettingContainer>
+      <FormProvider {...methods}>
+        <S.SettingForm onSubmit={handleSubmit(onSubmit)}>
+          <SettingProfile initialImageUrl={data?.imageUrl} />
 
-        <NicknameForm onCheck={setIsNicknameChecked} />
+          <NicknameForm onCheck={setIsNicknameChecked} />
 
-        <EmailForm
-          emailState={emailState}
-          setEmailState={setEmailState}
-        />
-
-        <Input
-          inputSize='md'
-          label='전화번호'
-          {...register('phoneNumber', {
-            validate: validatePhoneNumber,
-          })}
-          onBlur={(e) => {
-            const formatted = formatPhoneNumber(e.target.value);
-            setValue('phoneNumber', formatted, { shouldValidate: true });
-          }}
-          error={errors.phoneNumber?.message}
-          width='34.5rem'
-        />
-
-        <Textarea
-          textareaSize='md'
-          label='자기소개'
-          {...register('description')}
-          error={errors.description?.message}
-          width='34.5rem'
-          minHeight='12.8rem'
-        />
-
-        <S.ButtonWrapper>
-          <OutlinedButton
-            size='md'
-            color='primary'
-            label='저장하기'
-            interactionVariant='normal'
-            type='submit'
-            isDisabled={!isValid || !isEmailStateValid(emailState)}
+          <EmailForm
+            emailState={emailState}
+            setEmailState={setEmailState}
           />
-        </S.ButtonWrapper>
-      </S.SettingForm>
-    </FormProvider>
+
+          <Input
+            inputSize='md'
+            label='전화번호'
+            {...register('phoneNumber', {
+              validate: validatePhoneNumber,
+            })}
+            onBlur={(e) => {
+              const formatted = formatPhoneNumber(e.target.value);
+              setValue('phoneNumber', formatted, { shouldValidate: true });
+            }}
+            error={errors.phoneNumber?.message}
+            width='34.5rem'
+          />
+
+          <Textarea
+            textareaSize='md'
+            label='자기소개'
+            {...register('description')}
+            error={errors.description?.message}
+            width='34.5rem'
+            minHeight='12.8rem'
+          />
+
+          <S.ButtonWrapper>
+            <OutlinedButton
+              size='md'
+              color='primary'
+              label='저장하기'
+              interactionVariant='normal'
+              type='submit'
+              isDisabled={!isValid || !isEmailStateValid(emailState)}
+            />
+          </S.ButtonWrapper>
+        </S.SettingForm>
+      </FormProvider>
+
+      <TextButton
+        size='lg'
+        label='상세 개인정보 설정'
+        color='assistive'
+        iconRight={<SettingIcon />}
+        interactionVariant='normal'
+        onClick={() => openApp('withdraw')}
+      />
+    </S.SettingContainer>
   );
 }

--- a/src/components/atoms/TextButton/TextButton.styled.ts
+++ b/src/components/atoms/TextButton/TextButton.styled.ts
@@ -6,20 +6,24 @@ import styled from '@emotion/styled';
 import { getInteraction, InteractionVariant } from '@/styles/interaction';
 
 type TextButtonColor = 'primary' | 'assistive';
-type TextButtonSize = 'sm' | 'md' | 'lg' | 'fillContainer';
+type TextButtonSize = 'sm' | 'md' | 'lg';
+type TextButtonAlign = 'center' | 'space-between';
 
 export interface TextButtonStyleProps {
   color: TextButtonColor;
   size: TextButtonSize;
   interactionVariant: InteractionVariant;
+  fillContainer?: boolean;
+  align?: TextButtonAlign;
 }
 
-const commonStyles = (theme: Theme) => css`
+const commonStyles = (theme: Theme, fillContainer?: boolean, align?: TextButtonAlign) => css`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: ${align};
   gap: 4px;
 
+  width: ${fillContainer ? '100%' : 'auto'};
   border: none;
   border-radius: ${theme.radius[4]};
   background-color: transparent;
@@ -64,23 +68,16 @@ const sizeStyles: Record<TextButtonSize, (theme: Theme) => SerializedStyles> = {
   lg: (theme) => css`
     ${theme.typography.body1.semibold};
   `,
-  fillContainer: (theme) => css`
-    ${theme.typography.body1.semibold};
-    width: 100%;
-  `,
 };
 
 const getInteractionColor = (theme: Theme, color: TextButtonColor) => {
-  if (color === 'primary') {
-    return theme.semantic.primary.normal;
-  }
-  if (color === 'assistive') {
-    return theme.semantic.label.alternative;
-  }
+  if (color === 'primary') return theme.semantic.primary.normal;
+  if (color === 'assistive') return theme.semantic.label.alternative;
+  return theme.semantic.interaction.inactive;
 };
 
 export const TextButton = styled.button<TextButtonStyleProps>`
-  ${({ theme }) => commonStyles(theme)};
+  ${({ theme, fillContainer, align }) => commonStyles(theme, fillContainer, align)};
   ${({ theme, size }) => sizeStyles[size](theme)};
   ${({ theme, color }) => colorStyles[color](theme)};
   ${({ theme, interactionVariant, disabled, color }) =>

--- a/src/components/atoms/TextButton/TextButton.tsx
+++ b/src/components/atoms/TextButton/TextButton.tsx
@@ -18,6 +18,8 @@ export default function TextButton({
   isDisabled,
   onClick,
   interactionVariant,
+  fillContainer,
+  align = 'center',
 }: TextButtonProps) {
   return (
     <S.TextButton
@@ -26,10 +28,12 @@ export default function TextButton({
       disabled={isDisabled}
       onClick={onClick}
       interactionVariant={interactionVariant}
+      fillContainer={fillContainer}
+      align={align}
     >
-      <S.Icon>{iconLeft}</S.Icon>
+      {iconLeft && <S.Icon>{iconLeft}</S.Icon>}
       {label}
-      <S.Icon>{iconRight}</S.Icon>
+      {iconRight && <S.Icon>{iconRight}</S.Icon>}
     </S.TextButton>
   );
 }

--- a/src/components/organisms/Modal/Withdraw/Steps/ConfirmWithdraw/ConfirmWithdraw.styled.ts
+++ b/src/components/organisms/Modal/Withdraw/Steps/ConfirmWithdraw/ConfirmWithdraw.styled.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const ConfirmWithdraw = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.title3.bold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1.2rem;
+`;

--- a/src/components/organisms/Modal/Withdraw/Steps/ConfirmWithdraw/ConfirmWithdraw.tsx
+++ b/src/components/organisms/Modal/Withdraw/Steps/ConfirmWithdraw/ConfirmWithdraw.tsx
@@ -1,0 +1,46 @@
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import { useAppModalStore } from '@/stores/useModalStore';
+
+import * as S from './ConfirmWithdraw.styled';
+
+export interface ConfirmWithdrawProps {
+  onConfirm: () => void;
+}
+
+export default function ConfirmWithdraw({ onConfirm }: ConfirmWithdrawProps) {
+  const { close } = useAppModalStore();
+
+  return (
+    <S.ConfirmWithdraw>
+      <S.TextWrapper>
+        <S.Title>코그니어, 정말 탈퇴할건가요?</S.Title>
+        <S.Description>
+          문을 완전히 닫으면,
+          <br />
+          나중에 다시 돌아오기 힘들 수 있어요...😢
+          <br />
+          나를 찾는 여정을 포기하지 말아요
+        </S.Description>
+      </S.TextWrapper>
+
+      <S.ButtonWrapper>
+        <OutlinedButton
+          size='lg'
+          color='assistive'
+          label='탈퇴할래요'
+          fillContainer
+          interactionVariant='normal'
+          onClick={onConfirm}
+        />
+        <OutlinedButton
+          size='lg'
+          color='primary'
+          label='더 있을래요'
+          fillContainer
+          interactionVariant='normal'
+          onClick={close}
+        />
+      </S.ButtonWrapper>
+    </S.ConfirmWithdraw>
+  );
+}

--- a/src/components/organisms/Modal/Withdraw/Steps/InputReason/InputReason.styled.ts
+++ b/src/components/organisms/Modal/Withdraw/Steps/InputReason/InputReason.styled.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const InputReason = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.title3.bold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;

--- a/src/components/organisms/Modal/Withdraw/Steps/InputReason/InputReason.tsx
+++ b/src/components/organisms/Modal/Withdraw/Steps/InputReason/InputReason.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useFormContext } from 'react-hook-form';
+
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import Textarea from '@/components/molecules/Textarea/Textarea';
+
+import * as S from './InputReason.styled';
+
+export interface InputReasonProps {
+  onConfirm: () => void;
+}
+
+export default function InputReason({ onConfirm }: InputReasonProps) {
+  const { register } = useFormContext<{ reason: string }>();
+
+  return (
+    <S.InputReason>
+      <S.Title>이유를 알려줄 수 있어요?</S.Title>
+
+      <Textarea
+        textareaSize='lg'
+        minHeight='15.5rem'
+        {...register('reason', { required: true })}
+      />
+
+      <OutlinedButton
+        type='submit'
+        size='lg'
+        color='primary'
+        label='제출하기'
+        fillContainer
+        interactionVariant='normal'
+        onClick={onConfirm}
+      />
+    </S.InputReason>
+  );
+}

--- a/src/components/organisms/Modal/Withdraw/Steps/SupportContact/SupportContact.styled.ts
+++ b/src/components/organisms/Modal/Withdraw/Steps/SupportContact/SupportContact.styled.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const SupportContact = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.4rem;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.body1.medium};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;
+
+export const Email = styled.p`
+  width: 100%;
+  padding: 0.8rem 3.2rem;
+  border: 1px solid ${({ theme }) => theme.semantic.line.normal};
+  border-radius: 1000px;
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+
+  text-align: center;
+`;

--- a/src/components/organisms/Modal/Withdraw/Steps/SupportContact/SupportContact.tsx
+++ b/src/components/organisms/Modal/Withdraw/Steps/SupportContact/SupportContact.tsx
@@ -1,0 +1,41 @@
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import TextButton from '@/components/atoms/TextButton/TextButton';
+import { useAppModalStore } from '@/stores/useModalStore';
+
+import * as S from './SupportContact.styled';
+
+export interface SupportContactProps {
+  onStartWithdraw: () => void;
+}
+
+export default function SupportContact({ onStartWithdraw }: SupportContactProps) {
+  const { close } = useAppModalStore();
+
+  return (
+    <S.SupportContact>
+      <S.ContentWrapper>
+        <S.Title>
+          개인정보 설정에 문제가 있다면
+          <br />
+          아래 메일로 문의를 보내주세요
+        </S.Title>
+        <S.Email>oncognier@gmail.com</S.Email>
+        <OutlinedButton
+          label='확인'
+          size='lg'
+          color='primary'
+          interactionVariant='normal'
+          onClick={close}
+          fillContainer
+        />
+      </S.ContentWrapper>
+      <TextButton
+        label='코그룸 탈퇴하기'
+        size='sm'
+        color='assistive'
+        interactionVariant='normal'
+        onClick={onStartWithdraw}
+      />
+    </S.SupportContact>
+  );
+}

--- a/src/components/organisms/Modal/Withdraw/Steps/WithdrawComplete/WithdrawComplete.styled.ts
+++ b/src/components/organisms/Modal/Withdraw/Steps/WithdrawComplete/WithdrawComplete.styled.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const WithdrawComplete = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.title3.bold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.label.alternative};
+
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1rem;
+`;

--- a/src/components/organisms/Modal/Withdraw/Steps/WithdrawComplete/WithdrawComplete.tsx
+++ b/src/components/organisms/Modal/Withdraw/Steps/WithdrawComplete/WithdrawComplete.tsx
@@ -1,0 +1,46 @@
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import { useAppModalStore } from '@/stores/useModalStore';
+
+import * as S from './WithdrawComplete.styled';
+
+export interface WithdrawCompleteProps {
+  onConfirm: () => void;
+}
+
+export default function WithdrawComplete({ onConfirm }: WithdrawCompleteProps) {
+  const { close } = useAppModalStore();
+
+  return (
+    <S.WithdrawComplete>
+      <S.TextWrapper>
+        <S.Title>아쉽지만, 안녕 코그니어</S.Title>
+        <S.Description>
+          30일 내 언제든 돌아올 수 있어요.
+          <br />
+          다시 로그인 하기만 하면 돼요
+          <br />
+          이후, 내 정보는 완전히 삭제됩니다.
+        </S.Description>
+      </S.TextWrapper>
+
+      <S.ButtonWrapper>
+        <OutlinedButton
+          size='lg'
+          color='assistive'
+          label='알겠어요, 안녕!'
+          fillContainer
+          interactionVariant='normal'
+          onClick={onConfirm}
+        />
+        <OutlinedButton
+          size='lg'
+          color='primary'
+          label='탈퇴 안할래요'
+          fillContainer
+          interactionVariant='normal'
+          onClick={close}
+        />
+      </S.ButtonWrapper>
+    </S.WithdrawComplete>
+  );
+}

--- a/src/components/organisms/Modal/Withdraw/Steps/index.ts
+++ b/src/components/organisms/Modal/Withdraw/Steps/index.ts
@@ -1,0 +1,4 @@
+export { default as SupportContact } from './SupportContact/SupportContact';
+export { default as ConfirmWithdraw } from './ConfirmWithdraw/ConfirmWithdraw';
+export { default as InputReason } from './InputReason/InputReason';
+export { default as WithdrawComplete } from './WithdrawComplete/WithdrawComplete';

--- a/src/components/organisms/Modal/Withdraw/Withdraw.tsx
+++ b/src/components/organisms/Modal/Withdraw/Withdraw.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { WITHDRAW_STEP, WithdrawStep } from '@/constants/common';
+import { WithdrawFormFields } from '@/types/form';
+
+import { SupportContact, ConfirmWithdraw, InputReason, WithdrawComplete } from './Steps';
+
+export default function Withdraw() {
+  const [step, setStep] = useState<WithdrawStep>(WITHDRAW_STEP.SUPPORT_CONTACT);
+
+  const methods = useForm<WithdrawFormFields>({
+    mode: 'onChange',
+    defaultValues: { reason: '' },
+  });
+
+  const handleComplete = () => {
+    const reason = methods.getValues('reason');
+    console.log('탈퇴 사유:', reason);
+  };
+
+  return (
+    <FormProvider {...methods}>
+      {step === WITHDRAW_STEP.SUPPORT_CONTACT && (
+        <SupportContact onStartWithdraw={() => setStep(WITHDRAW_STEP.CONFIRM)} />
+      )}
+
+      {step === WITHDRAW_STEP.CONFIRM && <ConfirmWithdraw onConfirm={() => setStep(WITHDRAW_STEP.INPUT_REASON)} />}
+
+      {step === WITHDRAW_STEP.INPUT_REASON && <InputReason onConfirm={() => setStep(WITHDRAW_STEP.COMPLETE)} />}
+
+      {step === WITHDRAW_STEP.COMPLETE && <WithdrawComplete onConfirm={handleComplete} />}
+    </FormProvider>
+  );
+}

--- a/src/components/organisms/Modal/Withdraw/Withdraw.tsx
+++ b/src/components/organisms/Modal/Withdraw/Withdraw.tsx
@@ -4,11 +4,15 @@ import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { WITHDRAW_STEP, WithdrawStep } from '@/constants/common';
+import { useWithdrawMutation } from '@/hooks/api/auth/useWithdraw';
+import { useAppModalStore } from '@/stores/useModalStore';
 import { WithdrawFormFields } from '@/types/form';
 
 import { SupportContact, ConfirmWithdraw, InputReason, WithdrawComplete } from './Steps';
 
 export default function Withdraw() {
+  const { withdraw } = useWithdrawMutation();
+  const { close } = useAppModalStore();
   const [step, setStep] = useState<WithdrawStep>(WITHDRAW_STEP.SUPPORT_CONTACT);
 
   const methods = useForm<WithdrawFormFields>({
@@ -18,7 +22,8 @@ export default function Withdraw() {
 
   const handleComplete = () => {
     const reason = methods.getValues('reason');
-    console.log('탈퇴 사유:', reason);
+    withdraw({ reason });
+    close();
   };
 
   return (

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -9,6 +9,7 @@ import Error, { ErrorProps } from './Error/Error';
 import Login from './Login/Login';
 import Logout from './Logout/Logout';
 import Signup, { SignupProps } from './Signup/Signup';
+import Withdraw from './Withdraw/Withdraw';
 
 export type AppModalProps = {
   login: undefined;
@@ -16,6 +17,7 @@ export type AppModalProps = {
   logout: undefined;
   dailyAnswerPost: DailyAnswerPostProps;
   dailyShare: DailyShareProps;
+  withdraw: undefined;
 };
 
 export type AlertModalProps = {
@@ -31,6 +33,7 @@ export const AppModalRegistry = {
   logout: { Component: Logout, disableOutsideClick: false },
   dailyAnswerPost: { Component: DailyAnswerPost, disableOutsideClick: false },
   dailyShare: { Component: DailyShare, disableOutsideClick: false },
+  withdraw: { Component: Withdraw, disableOutsideClick: false },
 } satisfies ModalMap<AppModalProps>;
 
 export const AlertModalRegistry = {

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -23,6 +23,7 @@ export const END_POINTS_V1 = {
     SEND_EMAIL: `${BASE_PATH_V1.AUTH}/email-verification`,
     CHECK_EMAIL_VERIFIED: `${BASE_PATH_V1.AUTH}/email/status`,
     NICKNAME: `${BASE_PATH_V1.AUTH}/nickname`,
+    WITHDRAW: `${BASE_PATH_V1.AUTH}/withdraw`,
     REISSUE_TOKEN: `${BASE_PATH_V1.AUTH}/reissue`,
   },
   MEMBERS: {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -40,6 +40,15 @@ export const SIGNUP_STEP = {
 
 export type SignupStep = (typeof SIGNUP_STEP)[keyof typeof SIGNUP_STEP];
 
+export const WITHDRAW_STEP = {
+  SUPPORT_CONTACT: 'SUPPORT_CONTACT',
+  CONFIRM: 'CONFIRM',
+  INPUT_REASON: 'INPUT_REASON',
+  COMPLETE: 'COMPLETE',
+} as const;
+
+export type WithdrawStep = (typeof WITHDRAW_STEP)[keyof typeof WITHDRAW_STEP];
+
 export const WEEK_DAYS = ['월', '화', '수', '목', '금', '토', '일'] as const;
 
 export const SOCIAL_LINKS = {

--- a/src/hooks/api/auth/useWithdraw.ts
+++ b/src/hooks/api/auth/useWithdraw.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { authApi } from '@/api/authApis';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useAlertModalStore } from '@/stores/useModalStore';
+
+export const useWithdrawMutation = () => {
+  const { clearToken } = useAuthStore();
+  const { open } = useAlertModalStore();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: authApi.withdraw,
+    onSuccess: () => {
+      clearToken();
+      queryClient.clear();
+      router.push('/');
+    },
+    onError: () => {
+      open('error', { message: '회원 탈퇴에 실패했습니다.' });
+    },
+  });
+
+  return { withdraw: mutation.mutate };
+};

--- a/src/mocks/data/auth/withdrawData.ts
+++ b/src/mocks/data/auth/withdrawData.ts
@@ -1,0 +1,4 @@
+export const withdrawSuccess = {
+  code: 'SUCCESS',
+  message: '회원 탈퇴에 성공했습니다.',
+};

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,7 +1,13 @@
 import { http, HttpResponse } from 'msw';
 
 import { END_POINTS_V1, HTTP_STATUS_CODE } from '@/constants/api';
-import { CheckEmailVerifiedRequest, LoginRequest, SendEmailRequest, SignupRequest } from '@/types/auth';
+import {
+  CheckEmailVerifiedRequest,
+  LoginRequest,
+  SendEmailRequest,
+  SignupRequest,
+  WithdrawRequest,
+} from '@/types/auth';
 
 import { checkEmailVerifiedError, checkEmailVerifiedSuccess } from '../data/auth/checkEmailVerifiedData';
 import {
@@ -15,6 +21,7 @@ import { logoutSuccess } from '../data/auth/logoutData';
 import { reissueError, reissueSuccess } from '../data/auth/reissueTokenData';
 import { sendEmailError, sendEmailSuccess } from '../data/auth/sendEmailData';
 import { signupError, signupSuccess } from '../data/auth/signupData';
+import { withdrawSuccess } from '../data/auth/withdrawData';
 
 export const authHandlers = [
   http.post(END_POINTS_V1.AUTH.LOGIN, async ({ request }) => {
@@ -89,6 +96,12 @@ export const authHandlers = [
 
   http.post(END_POINTS_V1.AUTH.LOGOUT, async () => {
     return new HttpResponse(JSON.stringify(logoutSuccess), {
+      status: HTTP_STATUS_CODE.OK,
+    });
+  }),
+
+  http.delete(END_POINTS_V1.AUTH.WITHDRAW, async () => {
+    return new HttpResponse(JSON.stringify(withdrawSuccess), {
       status: HTTP_STATUS_CODE.OK,
     });
   }),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -35,3 +35,7 @@ export interface SignupRequest {
   email: string;
   nickname: string;
 }
+
+export interface WithdrawRequest {
+  reason: string;
+}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -27,3 +27,7 @@ export interface MemberDailyFormFields {
   startDate: Dayjs | null;
   endDate: Dayjs | null;
 }
+
+export interface WithdrawFormFields {
+  reason: string;
+}


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #206 

## 📋 작업 내용

- 회원 탈퇴 단계 구현 및 모달 추가
- 개인정보 설정 화면에 버튼 추가
- 회원 탈퇴 api 추가

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)

백엔드에서 provider 값이 확정되면 그에 맞춰 추가하겠습니다.