### PR TITLE
[FIX] Hide OAuth callback page from browser history after login #228

### DIFF
--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -32,11 +32,11 @@ export const useLoginMutation = () => {
         });
       }
 
-      router.push('/daily');
+      router.replace('/daily');
     },
     onError: () => {
       openAlert('error', { message: '로그인 중 오류가 발생했습니다.' });
-      router.push('/');
+      router.replace('/');
     },
   });
 

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -1,12 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 import { authApi } from '@/api/authApis';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAlertModalStore } from '@/stores/useModalStore';
 
 export const useSignupMutation = (onSuccess?: () => void) => {
-  const router = useRouter();
   const { open } = useAlertModalStore();
   const setToken = useAuthStore((state) => state.setToken);
 
@@ -16,11 +14,9 @@ export const useSignupMutation = (onSuccess?: () => void) => {
       const accessToken = response.headers['authorization']?.replace(/^Bearer\s/i, '');
       if (accessToken) setToken(accessToken);
       onSuccess?.();
-      router.push('/daily');
     },
     onError: () => {
       open('error', { message: '회원가입에 실패했습니다.' });
-      router.push('/');
     },
   });
 


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #228 

## 📋 작업 내용

- 로그인 성공 시, OAuth 콜백 페이지가 히스토리 스택에 남지 않도록 replace로 라우팅 처리함
→ 뒤로가기 시 콜백 페이지가 노출되지 않음

- 회원가입 성공 또는 에러 시, 추가 라우팅 제거
→ 회원가입은 로그인 이후 이어지므로 별도 페이지 이동이 불필요하며,
같은 페이지로의 불필요한 이동은 깜빡임을 유발해 UX에 부정적일 수 있음

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
