### PR TITLE
[RELEASE] Sync release/0.0.2 → develop

### DIFF
--- a/src/app/(shared)/(standard)/admin/_components/DailyListRow/DailyListRow.styled.ts
+++ b/src/app/(shared)/(standard)/admin/_components/DailyListRow/DailyListRow.styled.ts
@@ -10,6 +10,12 @@ export const DailyListRow = styled.div`
   width: 100%;
   height: 10.8rem;
   padding: 2.4rem 3.2rem;
+
+  border-bottom: 1px solid ${({ theme }) => theme.semantic.line.normal};
+
+  &:last-child {
+    border-bottom: none;
+  }
 `;
 
 export const MemberInfoWrapper = styled.div`

--- a/src/app/(shared)/(standard)/admin/users/_components/UserListRow/UserListRow.styled.ts
+++ b/src/app/(shared)/(standard)/admin/users/_components/UserListRow/UserListRow.styled.ts
@@ -10,6 +10,12 @@ export const UserListRow = styled.div`
   width: 100%;
   padding: 2.4rem 3.2rem;
 
+  border-bottom: 1px solid ${({ theme }) => theme.semantic.line.normal};
+
+  &:last-child {
+    border-bottom: none;
+  }
+
   cursor: pointer;
 `;
 

--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
@@ -44,21 +44,17 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
       return;
     }
 
+    if (!isFirstAnswer.current) {
+      openAlertModal('dailyFirstAnswer', { assignedQuestionId, answer: inputValue });
+      isFirstAnswer.current = true;
+      return;
+    }
+
     submitDailyAnswer({ assignedQuestionId, answer: inputValue });
   };
 
   const handleEdit = () => {
     openAlertModal('dailyAnswerEdit', { assignedQuestionId, answer: inputValue, redirectTo: '/daily' });
-  };
-
-  const handleFocus = () => {
-    if (!isFirstAnswer.current && isLoggedIn) {
-      openAlertModal('alert', {
-        message: '작성한 답변은 오늘 자정까지만 바꿀 수 있어요',
-      });
-      isFirstAnswer.current = true;
-      return;
-    }
   };
 
   useEffect(() => {
@@ -97,7 +93,6 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
             onChange={(e) => {
               setInputValue(e.target.value);
             }}
-            onFocus={handleFocus}
           />
         </S.InputGroup>
 

--- a/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.styled.ts
+++ b/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.styled.ts
@@ -8,22 +8,14 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
-  gap: ${({ theme }) => theme.spacing[32]};
+  gap: 3.2rem;
 
-  padding: ${({ theme }) => theme.spacing[12]} ${({ theme }) => theme.spacing[24]};
   background-color: ${({ theme }) => theme.semantic.background.normal.normal};
   border-radius: ${({ theme }) => theme.radius[8]};
 `;
 
-export const TextWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing[16]};
-`;
-
 export const Title = styled.p`
-  ${({ theme }) => theme.typography.body2.regular};
+  ${({ theme }) => theme.typography.headline1.semibold};
   color: ${({ theme }) => theme.semantic.label.normal};
 
   text-align: center;

--- a/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.tsx
+++ b/src/components/organisms/Modal/Daily/FirstAnswer/DailyFirstAnswer.tsx
@@ -1,25 +1,36 @@
 'use client';
 
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
-import { useAppModalStore } from '@/stores/useModalStore';
+import { useSubmitDailyAnswerMutation } from '@/hooks/api/daily/useSubmitDailyAnswer';
+import { useAlertModalStore } from '@/stores/useModalStore';
 
 import * as S from './DailyFirstAnswer.styled';
 
-export default function DailyFirstAnswer() {
-  const { close } = useAppModalStore();
+export interface DailyFirstAnswerProps {
+  assignedQuestionId: number;
+  answer: string;
+}
+
+export default function DailyFirstAnswer({ assignedQuestionId, answer }: DailyFirstAnswerProps) {
+  const { close } = useAlertModalStore();
+  const { submitDailyAnswer } = useSubmitDailyAnswerMutation();
+
+  const handleSubmit = () => {
+    close();
+    submitDailyAnswer({ assignedQuestionId, answer });
+  };
 
   return (
     <S.Container>
-      <S.TextWrapper>
-        <S.Title>작성한 답변은 오늘 자정까지만 바꿀 수 있어요</S.Title>
-      </S.TextWrapper>
+      <S.Title>작성한 답변은 오늘 자정까지만 바꿀 수 있어요</S.Title>
 
       <OutlinedButton
-        label='확인했어요'
+        label='확인'
         size='sm'
         color='assistive'
         interactionVariant='normal'
-        onClick={close}
+        fillContainer
+        onClick={handleSubmit}
         type='submit'
       />
     </S.Container>

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -4,6 +4,7 @@ import Alert, { AlertProps } from './Alert/Alert';
 import ChangeRole, { ChangeRoleProps } from './ChangeRole/ChangeRole';
 import DailyShare, { DailyShareProps } from './Daily/DailyShare/DailyShare';
 import DailyAnswerEdit, { DailyAnswerEditProps } from './Daily/Edit/DailyAnswerEdit';
+import DailyFirstAnswer, { DailyFirstAnswerProps } from './Daily/FirstAnswer/DailyFirstAnswer';
 import DailyAnswerPost, { DailyAnswerPostProps } from './Daily/Post/DailyAnswerPost';
 import Error, { ErrorProps } from './Error/Error';
 import Login from './Login/Login';
@@ -23,6 +24,7 @@ export type AppModalProps = {
 export type AlertModalProps = {
   error: ErrorProps;
   alert: AlertProps;
+  dailyFirstAnswer: DailyFirstAnswerProps;
   dailyAnswerEdit: DailyAnswerEditProps;
   changeRole: ChangeRoleProps;
 };
@@ -39,6 +41,7 @@ export const AppModalRegistry = {
 export const AlertModalRegistry = {
   error: { Component: Error, disableOutsideClick: false },
   alert: { Component: Alert, disableOutsideClick: false },
+  dailyFirstAnswer: { Component: DailyFirstAnswer, disableOutsideClick: false },
   dailyAnswerEdit: { Component: DailyAnswerEdit, disableOutsideClick: false },
   changeRole: { Component: ChangeRole, disableOutsideClick: false },
 } satisfies ModalMap<AlertModalProps>;

--- a/src/constants/validationMessages.ts
+++ b/src/constants/validationMessages.ts
@@ -2,6 +2,7 @@ export const VALIDATION_MESSAGE = {
   EMAIL_PATTERN_ERROR: '이메일 형식이 아닙니다.',
   EMAIL_NOT_VERIFIED_ERROR: '이메일 인증이 실패했습니다.',
   EMAIL_EMPTY_FILED_ERROR: '이메일은 필수입니다.',
+  EMAIL_DUPLICATE_ERROR: '이미 존재하는 이메일입니다.',
 
   PHONENUMBER_PATTERN_ERROR: '전화번호 형식이 올바르지 않습니다.',
   PHONENUMBER_INVALID_CHARACTERS_ERROR: '전화번호는 숫자와 하이픈(-)만 입력할 수 있습니다.',
@@ -20,6 +21,7 @@ export const VALIDATION_FIELD_MAP: Partial<Record<ValidationErrorKey, string>> =
   EMAIL_PATTERN_ERROR: 'email',
   EMAIL_NOT_VERIFIED_ERROR: 'email',
   EMAIL_EMPTY_FILED_ERROR: 'email',
+  EMAIL_DUPLICATE_ERROR: 'email',
 
   PHONENUMBER_PATTERN_ERROR: 'phoneNumber',
   PHONENUMBER_INVALID_CHARACTERS_ERROR: 'phoneNumber',

--- a/src/hooks/api/auth/useLogin.ts
+++ b/src/hooks/api/auth/useLogin.ts
@@ -32,11 +32,11 @@ export const useLoginMutation = () => {
         });
       }
 
-      router.push('/daily');
+      router.replace('/daily');
     },
     onError: () => {
       openAlert('error', { message: '로그인 중 오류가 발생했습니다.' });
-      router.push('/');
+      router.replace('/');
     },
   });
 

--- a/src/hooks/api/auth/useSignup.ts
+++ b/src/hooks/api/auth/useSignup.ts
@@ -1,12 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 import { authApi } from '@/api/authApis';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAlertModalStore } from '@/stores/useModalStore';
 
 export const useSignupMutation = (onSuccess?: () => void) => {
-  const router = useRouter();
   const { open } = useAlertModalStore();
   const setToken = useAuthStore((state) => state.setToken);
 
@@ -16,11 +14,9 @@ export const useSignupMutation = (onSuccess?: () => void) => {
       const accessToken = response.headers['authorization']?.replace(/^Bearer\s/i, '');
       if (accessToken) setToken(accessToken);
       onSuccess?.();
-      router.push('/daily');
     },
     onError: () => {
       open('error', { message: '회원가입에 실패했습니다.' });
-      router.push('/');
     },
   });
 

--- a/src/utils/validators/setValidationError.ts
+++ b/src/utils/validators/setValidationError.ts
@@ -20,6 +20,6 @@ export function setValidationError<FormFields extends FieldValues>(
       message: VALIDATION_MESSAGE[code],
     });
   } else {
-    open('error', { message: '요청에 실패했습니다.' });
+    open('error', { message: error.message });
   }
 }


### PR DESCRIPTION
`release/0.0.2` 브랜치에서 릴리즈된 변경사항을 `develop` 브랜치에도 반영하기 위한 머지 PR입니다.

릴리즈 과정에서 수정된 버그 3건이 누락되지 않도록 개발 브랜치와의 이력 정합성을 맞추기 위함입니다.


## ✅ 포함된 변경 사항

- [FIX] 로그인/회원가입 후 뒤로가기 시 OAuth callback 페이지 라우팅 스택 제거 (#228)
- [FIX] 데일리 첫 답변 제출 시 모달 플로우 수정 (#233)
- [FIX] 중복된 이메일 입력 시 예외 처리 추가 (#230)


## 🧾 관련 이슈 및 PR

- 0.0.1 QA 이슈: #213
- 0.0.2 QA 이슈: #236
