### PR TITLE
[FEAT] Add alert modals on profile edit #247

### DIFF
--- a/src/app/(shared)/(standard)/mypage/setting/_components/EmailForm/EmailForm.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/_components/EmailForm/EmailForm.tsx
@@ -8,6 +8,7 @@ import { VALIDATION_MESSAGE } from '@/constants/validationMessages';
 import { useGetEmailStatusQuery } from '@/hooks/api/auth/useGetEmailStatus';
 import { useSendEmailMutation } from '@/hooks/api/auth/useSendEmail';
 import { useCooldown } from '@/hooks/useCooldown';
+import { useAlertModalStore } from '@/stores/useModalStore';
 import { validateEmail } from '@/utils/validators/userValidators';
 
 import * as S from './EmailForm.styled';
@@ -27,6 +28,7 @@ export default function EmailForm({ emailState, setEmailState }: EmailFormProps)
     formState: { errors },
   } = useFormContext<{ email: string }>();
 
+  const { open } = useAlertModalStore();
   const { value: isCooldown, start: startCooldown } = useCooldown(3000);
 
   const { sendEmail } = useSendEmailMutation(() => {
@@ -51,8 +53,9 @@ export default function EmailForm({ emailState, setEmailState }: EmailFormProps)
       const { data } = await refetchEmailStatus();
       if (data) {
         setEmailState('idle');
+        open('alert', { message: '변경되었습니다!' });
       } else {
-        setError('email', { message: VALIDATION_MESSAGE.EMAIL_NOT_VERIFIED_ERROR });
+        open('alert', { message: VALIDATION_MESSAGE.EMAIL_NOT_VERIFIED_ERROR });
       }
     }
   };

--- a/src/app/(shared)/(standard)/mypage/setting/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/page.tsx
@@ -53,7 +53,7 @@ export default function Setting() {
     setValue,
     reset,
     setError,
-    formState: { errors, isValid, dirtyFields },
+    formState: { errors, isValid },
   } = methods;
 
   const { editUserInfo } = useEditUserInfoMutation(setError);
@@ -65,7 +65,7 @@ export default function Setting() {
   }, [data, isLoading, reset]);
 
   const onSubmit = (formData: SettingFormFields) => {
-    if (dirtyFields.nickname && !isNicknameChecked) {
+    if (!isNicknameChecked) {
       openAlert('alert', { message: '닉네임 중복 확인을 완료해주세요.' });
       return;
     }
@@ -81,7 +81,10 @@ export default function Setting() {
         <S.SettingForm onSubmit={handleSubmit(onSubmit)}>
           <SettingProfile initialImageUrl={data?.imageUrl} />
 
-          <NicknameForm onCheck={setIsNicknameChecked} />
+          <NicknameForm
+            initialNickname={data?.nickname}
+            onCheck={setIsNicknameChecked}
+          />
 
           <EmailForm
             emailState={emailState}

--- a/src/app/(shared)/(standard)/mypage/setting/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/setting/page.tsx
@@ -35,8 +35,7 @@ const isEmailStateValid = (emailState: EmailState) => emailState === 'idle';
 
 export default function Setting() {
   const [emailState, setEmailState] = useState<EmailState>('idle');
-  const [isNicknameChecked, setIsNicknameChecked] = useState(true);
-
+  const [isNicknameValid, setIsNicknameValid] = useState(true);
   const { open: openApp } = useAppModalStore();
   const { open: openAlert } = useAlertModalStore();
   const { data, isLoading, isError } = useGetUserInfo();
@@ -61,12 +60,15 @@ export default function Setting() {
   useEffect(() => {
     if (data && !isLoading) {
       reset(getDefaultValues(data));
+      setIsNicknameValid(true);
     }
   }, [data, isLoading, reset]);
 
+  const isFormSubmittable = isValid && isEmailStateValid(emailState) && isNicknameValid;
+
   const onSubmit = (formData: SettingFormFields) => {
-    if (!isNicknameChecked) {
-      openAlert('alert', { message: '닉네임 중복 확인을 완료해주세요.' });
+    if (!isFormSubmittable) {
+      openAlert('alert', { message: '입력값을 다시 확인해주세요.' });
       return;
     }
 
@@ -83,7 +85,7 @@ export default function Setting() {
 
           <NicknameForm
             initialNickname={data?.nickname}
-            onCheck={setIsNicknameChecked}
+            onCheck={setIsNicknameValid}
           />
 
           <EmailForm
@@ -121,7 +123,7 @@ export default function Setting() {
               label='저장하기'
               interactionVariant='normal'
               type='submit'
-              isDisabled={!isValid || !isEmailStateValid(emailState)}
+              isDisabled={!isFormSubmittable}
             />
           </S.ButtonWrapper>
         </S.SettingForm>

--- a/src/hooks/api/member/useCheckNickname.ts
+++ b/src/hooks/api/member/useCheckNickname.ts
@@ -2,7 +2,6 @@ import { useMutation } from '@tanstack/react-query';
 import { UseFormSetError } from 'react-hook-form';
 
 import { memberApi } from '@/api/memberApis';
-import { useAlertModalStore } from '@/stores/useModalStore';
 import { setValidationError } from '@/utils/validators/setValidationError';
 
 export const useCheckNicknameMutation = (
@@ -10,19 +9,13 @@ export const useCheckNicknameMutation = (
   onSuccess?: () => void,
   onFailure?: () => void,
 ) => {
-  const { open } = useAlertModalStore();
-
   const mutation = useMutation({
     mutationFn: memberApi.checkNickname,
     onSuccess: (result) => {
       if (result) {
-        onSuccess?.();
+        onFailure?.();
       } else {
-        if (onFailure) {
-          onFailure();
-        } else {
-          open('error', { message: '닉네임 중복 확인에 실패했습니다.' });
-        }
+        onSuccess?.();
       }
     },
     onError: (error) => {

--- a/src/hooks/api/member/useEditUserInfo.ts
+++ b/src/hooks/api/member/useEditUserInfo.ts
@@ -3,16 +3,19 @@ import { UseFormSetError } from 'react-hook-form';
 
 import { memberApi } from '@/api/memberApis';
 import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAlertModalStore } from '@/stores/useModalStore';
 import { SettingFormFields } from '@/types/form';
 import { setValidationError } from '@/utils/validators/setValidationError';
 
 export const useEditUserInfoMutation = (setError?: UseFormSetError<SettingFormFields>) => {
+  const { open } = useAlertModalStore();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: memberApi.editUserInfo,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...MEMBER_QUERY_KEYS.MEMBER_SUMMARY] });
+      open('alert', { message: '저장되었습니다.' });
     },
     onError: (error) => {
       setValidationError<SettingFormFields>(error, setError);

--- a/src/utils/validators/setValidationError.ts
+++ b/src/utils/validators/setValidationError.ts
@@ -15,6 +15,11 @@ export function setValidationError<FormFields extends FieldValues>(
   const code = error.code as ValidationErrorKey;
   const field = VALIDATION_FIELD_MAP[code];
 
+  if (code === 'EMAIL_DUPLICATE_ERROR') {
+    open('alert', { message: VALIDATION_MESSAGE[code] });
+    return;
+  }
+
   if (field && setError) {
     setError(field as Path<FormFields>, {
       message: VALIDATION_MESSAGE[code],


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #247 

## 📋 작업 내용

- 이메일 변경 시 알람 모달 추가 ( 변경 완료, 변경 실패, 중복 여부 )
- 닉네임 변경 시 알람 모달 추가 ( 중복 여부 )
- 저장 시 알람 모달 추가 ( 저장 성공 )
- 닉네임 중복 확인 버튼, 저장 버튼 disable 상태 관리 수정

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
