### PR TITLE
[FEAT] marketing page #245

### DIFF
--- a/src/app/(shared)/(standard)/(legal)/marketing/page.styled.ts
+++ b/src/app/(shared)/(standard)/(legal)/marketing/page.styled.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Marketing = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  margin-bottom: 16.5rem;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.title2.bold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;
+
+export const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+`;
+
+export const Subtitle = styled.p`
+  ${({ theme }) => theme.typography.headline1.semibold};
+  color: ${({ theme }) => theme.semantic.label.neutral};
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  gap: 0.4rem;
+
+  ${({ theme }) => theme.typography.body1.regular};
+  color: ${({ theme }) => theme.semantic.label.neutral};
+`;
+
+export const ContentNumber = styled.p`
+  width: 1.6rem;
+  ${({ theme }) => theme.typography.body1.regular};
+  color: ${({ theme }) => theme.semantic.label.neutral};
+`;

--- a/src/app/(shared)/(standard)/(legal)/marketing/page.tsx
+++ b/src/app/(shared)/(standard)/(legal)/marketing/page.tsx
@@ -1,3 +1,29 @@
+import * as S from './page.styled';
+
 export default function Marketing() {
-  return <div>Marketing</div>;
+  return (
+    <S.Marketing>
+      <S.Title>마케팅 정보 수신동의</S.Title>
+
+      <S.Section>
+        <S.Subtitle>제 13조. 광고성 정보 수신동의</S.Subtitle>
+        <S.ContentWrapper>
+          <S.Content>
+            <S.ContentNumber>1.</S.ContentNumber>
+            회사는 회원에게 서비스 안내, 이벤트, 프로모션 등 마케팅 목적의 정보를 전자적 방법(이메일, 문자메시지, 앱
+            푸시 등)으로 전송할 수 있으며, 이는 사전 동의를 받은 경우에 한합니다.
+          </S.Content>
+          <S.Content>
+            <S.ContentNumber>2.</S.ContentNumber>
+            회원은 언제든지 수신 거부를 할 수 있으며, 수신 거부 방법은 각 메시지 하단 또는 이메일을 통한 공지사항 형태로
+            안내됩니다.
+          </S.Content>
+          <S.Content>
+            <S.ContentNumber>3.</S.ContentNumber> 마케팅 정보 수신 동의는 필수가 아니며, 동의 여부와 관계없이 기본
+            서비스 이용에 제한은 없습니다.
+          </S.Content>
+        </S.ContentWrapper>
+      </S.Section>
+    </S.Marketing>
+  );
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #245 

## 📋 작업 내용

- marketing page

마케팅은 다른 legal 페이지와는 다르게 따로 165px 만큼의 margin-bottom 이 있어서 따로 추가했습니다.

<img width="651" height="345" alt="image" src="https://github.com/user-attachments/assets/1c4d2767-f511-4fdf-8064-86e572ae604f" />

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)

content 내용 지금 contentNumber 만 구분했는데 내용도 구분해서 할까요?
