### PR TITLE
[FEAT] 회원가입 단계 문구 수정 #259

### DIFF
--- a/src/components/organisms/Modal/Signup/Signup.tsx
+++ b/src/components/organisms/Modal/Signup/Signup.tsx
@@ -40,12 +40,7 @@ export default function Signup({ provider, providerId, email, nickname }: Signup
         />
       )}
 
-      {step === SIGNUP_STEP.INPUT_NEW_EMAIL && (
-        <InputEmail
-          email={email}
-          onConfirm={() => setStep(SIGNUP_STEP.VERIFY_EMAIL)}
-        />
-      )}
+      {step === SIGNUP_STEP.INPUT_NEW_EMAIL && <InputEmail onConfirm={() => setStep(SIGNUP_STEP.VERIFY_EMAIL)} />}
 
       {step === SIGNUP_STEP.VERIFY_EMAIL && (
         <VerifyEmail

--- a/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
@@ -41,7 +41,7 @@ export default function CheckEmail({ email, onConfirm, onChangeEmail }: CheckEma
 
       <S.ButtonWrapper>
         <SolidButton
-          label='이 이메일로 시작하기'
+          label='맞아요'
           size='md'
           color='primary'
           interactionVariant='normal'
@@ -49,7 +49,7 @@ export default function CheckEmail({ email, onConfirm, onChangeEmail }: CheckEma
           fillContainer
         />
         <OutlinedButton
-          label='다른 이메일 사용하기'
+          label='다른 이메일 쓸게요'
           size='md'
           color='assistive'
           interactionVariant='normal'

--- a/src/components/organisms/Modal/Signup/Steps/InputEmail/InputEmail.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/InputEmail/InputEmail.tsx
@@ -11,11 +11,10 @@ import { validateEmail } from '@/utils/validators/userValidators';
 import * as S from './InputEmail.styled';
 
 export interface InputEmailProps {
-  email: string;
   onConfirm: () => void;
 }
 
-export default function InputEmail({ email, onConfirm }: InputEmailProps) {
+export default function InputEmail({ onConfirm }: InputEmailProps) {
   const {
     register,
     handleSubmit,
@@ -41,7 +40,7 @@ export default function InputEmail({ email, onConfirm }: InputEmailProps) {
         <Input
           label='이메일'
           inputSize='md'
-          placeholder={email}
+          placeholder='cognier@cogroom.com'
           {...register('email', {
             required: VALIDATION_MESSAGE.EMAIL_EMPTY_FILED_ERROR,
             validate: validateEmail,


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #259 

## 📋 작업 내용

- CheckEmail 버튼 문구 변경
<img width="423" height="469" alt="스크린샷 2025-07-17 오후 2 55 28" src="https://github.com/user-attachments/assets/54dc262f-5d0d-4bc9-b69a-07204dd50c65" />

- InputEmail placeholder 변경
<img width="428" height="472" alt="스크린샷 2025-07-17 오후 2 55 47" src="https://github.com/user-attachments/assets/d9e87fb6-b9b8-4428-a48d-286d6ba3b32f" />


## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
