### PR TITLE
[FEAT] 데일리 유효성 에러모달 서브문구 제거 #261

### DIFF
--- a/src/hooks/api/daily/useEditDailyAnswer.ts
+++ b/src/hooks/api/daily/useEditDailyAnswer.ts
@@ -20,13 +20,13 @@ export const useEditDailyAnswerMutation = () => {
     onError: (error: HTTPError) => {
       switch (error.code) {
         case 'ANSWER_NOTBLANK_ERROR':
-          open('error', { message: '한 글자라도 적어주세요' });
+          open('alert', { message: '한 글자라도 적어주세요' });
           break;
         case 'ANSWER_SIZE_ERROR':
-          open('error', { message: '내용을 조금만 줄여볼까요?' });
+          open('alert', { message: '내용을 조금만 줄여볼까요?' });
           break;
         case 'ANSWER_TIME_EXPIRED':
-          open('error', { message: '앗.. 자정이 지나 수정할 수 없어요' });
+          open('alert', { message: '앗.. 자정이 지나 수정할 수 없어요' });
           break;
         default:
           open('error', { message: error.message });

--- a/src/hooks/api/daily/useSubmitDailyAnswer.ts
+++ b/src/hooks/api/daily/useSubmitDailyAnswer.ts
@@ -23,13 +23,13 @@ export const useSubmitDailyAnswerMutation = () => {
     onError: (error: HTTPError) => {
       switch (error.code) {
         case 'ANSWER_NOTBLANK_ERROR':
-          openAlert('error', { message: '한 글자라도 적어주세요' });
+          openAlert('alert', { message: '한 글자라도 적어주세요' });
           break;
         case 'ANSWER_SIZE_ERROR':
-          openAlert('error', { message: '내용을 조금만 줄여볼까요?' });
+          openAlert('alert', { message: '내용을 조금만 줄여볼까요?' });
           break;
         case 'ANSWER_TIME_EXPIRED':
-          openAlert('error', { message: '앗.. 자정이 지나 수정할 수 없어요' });
+          openAlert('alert', { message: '앗.. 자정이 지나 수정할 수 없어요' });
           break;
         default:
           openAlert('error', { message: error.message });


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #261 

## 📋 작업 내용

- 제출, 수정 시 유효성 모달에 서브 문구 제거 ( error -> alert 모달로 변경 )

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
