### PR TITLE
[RELEASE] v0.2.1

### DIFF
--- a/src/app/(shared)/(anomaly)/(home)/_components/Cogpoint/Cogpoint.tsx
+++ b/src/app/(shared)/(anomaly)/(home)/_components/Cogpoint/Cogpoint.tsx
@@ -1,4 +1,3 @@
-import Graph from '@/assets/icons/graph.svg';
 import { COGPOINT_CARDS } from '@/constants/common';
 
 import * as S from './Cogpoint.styled';
@@ -7,7 +6,7 @@ import Section from '../Section/Section';
 export default function Cogpoint() {
   return (
     <Section
-      title='코그 포인트'
+      title='생각하는 방에서 할 수 있는 것'
       subtitle='단순한 학습이 아닌 나를 알아가고 이해하는 여정을 제공합니다'
     >
       <S.Wrapper>

--- a/src/app/(shared)/(anomaly)/(home)/_components/Community/Community.tsx
+++ b/src/app/(shared)/(anomaly)/(home)/_components/Community/Community.tsx
@@ -6,8 +6,8 @@ import Section from '../Section/Section';
 export default function Community() {
   return (
     <Section
-      title='커뮤니티'
-      subtitle='단순한 학습이 아닌 나를 알아가고 이해하는 여정을 제공합니다'
+      title='우리는 생각하는 사람들, 코그니어'
+      subtitle='혼자서는 닿을 수 없던 깊은 성찰을 함께 나누는 공간입니다'
     >
       <S.Wrapper>
         <a href='/community'>

--- a/src/app/(shared)/(anomaly)/(home)/_components/Content/Carousel/CarouselCard.styled.ts
+++ b/src/app/(shared)/(anomaly)/(home)/_components/Content/Carousel/CarouselCard.styled.ts
@@ -54,27 +54,16 @@ export const TextContainer = styled.div`
   width: 100%;
 `;
 
-export const HeroWrapper = styled.div`
+export const HeroTitle = styled.p`
   position: absolute;
-  top: 0;
+  top: 2rem;
   left: 0;
-  bottom: 0;
   right: 0;
   z-index: 2;
 
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 3.8rem;
-
-  padding: 2rem 1rem 1rem 1rem;
-`;
-
-export const HeroTitle = styled.p`
   ${({ theme }) => theme.typography.title2.bold};
   color: ${({ theme }) => theme.semantic.static.white};
 
-  width: 100%;
   text-align: center;
   white-space: pre-line;
 `;
@@ -90,6 +79,11 @@ export const Content = styled.p`
 `;
 
 export const Badge = styled.span`
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 2;
+
   padding: 0.4rem 1.2rem;
   ${({ theme }) => theme.typography.label2.regular};
   border: 1px solid ${({ theme }) => theme.semantic.primary.normal};

--- a/src/app/(shared)/(anomaly)/(home)/_components/Content/Carousel/CarouselCard.tsx
+++ b/src/app/(shared)/(anomaly)/(home)/_components/Content/Carousel/CarouselCard.tsx
@@ -38,10 +38,8 @@ export default function CarouselCard({
             style={{ objectFit: 'cover' }}
           />
           <S.Overlay gradientColor={gradientColor} />
-          <S.HeroWrapper>
-            <S.HeroTitle>{heroTitle}</S.HeroTitle>
-            <S.Badge>{contentType}</S.Badge>
-          </S.HeroWrapper>
+          <S.HeroTitle>{heroTitle}</S.HeroTitle>
+          <S.Badge>{contentType}</S.Badge>
         </S.ImageWrapper>
 
         <S.TextContainer>

--- a/src/app/(shared)/(anomaly)/(home)/_components/Content/Content.tsx
+++ b/src/app/(shared)/(anomaly)/(home)/_components/Content/Content.tsx
@@ -5,8 +5,8 @@ export default function Content() {
   return (
     <>
       <Section
-        title='콘텐츠'
-        subtitle='단순한 학습이 아닌 나를 알아가고 이해하는 여정을 제공합니다'
+        title='더욱 깊이 알아가는 나의 마음'
+        subtitle='심층 지식을 담은 PDF와 강의 콘텐츠입니다'
       >
         <Carousel />
       </Section>

--- a/src/app/(shared)/(standard)/adminguard/page.styled.ts
+++ b/src/app/(shared)/(standard)/adminguard/page.styled.ts
@@ -5,23 +5,11 @@ import styled from '@emotion/styled';
 export const AdminGuard = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
-  gap: 3.2rem;
 
   width: 100%;
   padding: 14rem 0;
-`;
-
-export const MessageWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-`;
-
-export const Description = styled.p`
-  ${({ theme }) => theme.typography.label1.regular};
-  color: ${({ theme }) => theme.semantic.primary.normal};
 `;
 
 export const MainMessage = styled.p`

--- a/src/app/(shared)/(standard)/adminguard/page.tsx
+++ b/src/app/(shared)/(standard)/adminguard/page.tsx
@@ -1,27 +1,11 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
-import SolidButton from '@/components/atoms/SolidButton/SolidButton';
-
 import * as S from './page.styled';
 
 export default function AdminGuard() {
-  const router = useRouter();
-
   return (
     <S.AdminGuard>
-      <S.MessageWrapper>
-        <S.MainMessage>해당 기능은 권한이 있는 사용자만 이용할 수 있어요!</S.MainMessage>
-      </S.MessageWrapper>
-
-      <SolidButton
-        size='sm'
-        color='primary'
-        label='홈으로 가기'
-        interactionVariant='normal'
-        onClick={() => router.push('/')}
-      />
+      <S.MainMessage>해당 기능은 권한이 있는 사용자만 이용할 수 있어요!</S.MainMessage>
     </S.AdminGuard>
   );
 }

--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.styled.ts
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.styled.ts
@@ -2,6 +2,7 @@
 
 import styled from '@emotion/styled';
 
+import { shakeAnimation } from '@/styles/animations';
 import { getInteraction } from '@/styles/interaction';
 
 export const QuestionCard = styled.div`
@@ -122,7 +123,7 @@ export const SubmitGroup = styled.div`
   gap: ${({ theme }) => theme.spacing[8]};
 `;
 
-export const CountValue = styled.div<{ isHundredOver?: boolean }>`
+export const CountValue = styled.div<{ isHundredOver?: boolean; isShaking?: boolean }>`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spacing[4]};
@@ -131,6 +132,8 @@ export const CountValue = styled.div<{ isHundredOver?: boolean }>`
   ${({ theme }) => theme.typography.label2.regular}
   color: ${({ theme, isHundredOver }) =>
     isHundredOver ? theme.semantic.status.destructive : theme.semantic.primary.normal};
+
+  ${({ isShaking }) => isShaking && shakeAnimation}
 `;
 
 export const Button = styled.button`

--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
@@ -4,9 +4,11 @@ import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 
 import CheckCircle from '@/assets/icons/checkcircle-fill.svg';
+import { DAILY_MAX_LENGTH } from '@/constants/common';
 import { DEFAULT_QUESTION_BACKGROUND } from '@/constants/image';
 import { useEditDailyAnswerMutation } from '@/hooks/api/daily/useEditDailyAnswer';
 import { useSubmitDailyAnswerMutation } from '@/hooks/api/daily/useSubmitDailyAnswer';
+import { useTextLimiter } from '@/hooks/useTextLimiter';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppModalStore, useAlertModalStore } from '@/stores/useModalStore';
 
@@ -20,7 +22,6 @@ interface QuestionProps {
 }
 
 export default function Question({ assignedQuestionId, question, answer, hasAnswered }: QuestionProps) {
-  const [inputValue, setInputValue] = useState(answer ?? '');
   const [isAnswered, setIsAnswered] = useState<boolean>(answer ? true : false);
   const isFirstAnswer = useRef<boolean>(hasAnswered);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -30,6 +31,13 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
   const { open } = useAppModalStore();
   const { open: openAlertModal } = useAlertModalStore();
   const { isLoggedIn } = useAuthStore();
+
+  const {
+    value: answerValue,
+    setValue: setAnswerValue,
+    isShaking,
+    isOverLimit,
+  } = useTextLimiter(DAILY_MAX_LENGTH, answer ?? '');
 
   const handleInput = () => {
     const el = textareaRef.current;
@@ -46,12 +54,12 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
     }
 
     if (!isFirstAnswer.current) {
-      openAlertModal('dailyFirstAnswer', { assignedQuestionId, answer: inputValue });
+      openAlertModal('dailyFirstAnswer', { assignedQuestionId, answer: answerValue });
       isFirstAnswer.current = true;
       return;
     }
 
-    submitDailyAnswer({ assignedQuestionId, answer: inputValue });
+    submitDailyAnswer({ assignedQuestionId, answer: answerValue });
   };
 
   const handleEdit = () => {
@@ -60,19 +68,19 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
       return;
     }
 
-    editDailyAnswer({ assignedQuestionId, answer: inputValue });
+    editDailyAnswer({ assignedQuestionId, answer: answerValue });
   };
 
   useEffect(() => {
     if (answer) {
-      setInputValue(answer);
+      setAnswerValue(answer);
       setIsAnswered(true);
     }
-  }, [answer]);
+  }, [answer, setAnswerValue]);
 
   useEffect(() => {
     handleInput();
-  }, [inputValue]);
+  }, [answerValue]);
 
   return (
     <S.QuestionCard>
@@ -94,16 +102,21 @@ export default function Question({ assignedQuestionId, question, answer, hasAnsw
           )}
           <S.Input
             ref={textareaRef}
-            value={inputValue}
+            value={answerValue}
             placeholder='음... 나는'
             onChange={(e) => {
-              setInputValue(e.target.value);
+              setAnswerValue(e.target.value);
             }}
           />
         </S.InputGroup>
 
         <S.SubmitGroup>
-          <S.CountValue isHundredOver={inputValue.length > 100}>{inputValue.length}/100</S.CountValue>
+          <S.CountValue
+            isHundredOver={isOverLimit}
+            isShaking={isShaking}
+          >
+            {answerValue.length}/{DAILY_MAX_LENGTH - 1}
+          </S.CountValue>
           <S.Button onClick={isAnswered ? handleEdit : handleSubmit}>{isAnswered ? '수정하기' : '제출하기'}</S.Button>
         </S.SubmitGroup>
       </S.Form>

--- a/src/app/(shared)/(standard)/mypage/notification/layout.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/layout.tsx
@@ -5,7 +5,9 @@ export default function NotificationLayout({ children }: { children: React.React
     <S.NotificationLayout>
       <S.TextWrapper>
         <S.Heading>푸시 및 카톡 알림</S.Heading>
-        <S.Description>알림을 켜 두면 코그룸과 함께 더욱 성장할 수 있어요.</S.Description>
+        <S.Description>
+          알림을 켜 두면 코그룸과 함께 더욱 성장할 수 있어요. (*알림 기능은 아직 지원하지 않아요!)
+        </S.Description>
       </S.TextWrapper>
       {children}
     </S.NotificationLayout>

--- a/src/app/(shared)/(standard)/mypage/notification/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/notification/page.tsx
@@ -8,11 +8,11 @@ import * as S from './page.styled';
 
 export default function Notification() {
   const [settings, setSettings] = useState({
-    push: true,
-    sound: true,
-    news: true,
-    streak: true,
-    marketing: true,
+    push: false,
+    sound: false,
+    news: false,
+    streak: false,
+    marketing: false,
   });
 
   const toggle = (key: keyof typeof settings) => {

--- a/src/components/organisms/EmptyState/EmptyState.styled.ts
+++ b/src/components/organisms/EmptyState/EmptyState.styled.ts
@@ -38,10 +38,3 @@ export const MainMessage = styled.p`
 
   text-align: center;
 `;
-
-export const Description = styled.p`
-  ${({ theme }) => theme.typography.label1.regular};
-  color: ${({ theme }) => theme.semantic.label.alternative};
-
-  text-align: center;
-`;

--- a/src/components/organisms/EmptyState/EmptyState.tsx
+++ b/src/components/organisms/EmptyState/EmptyState.tsx
@@ -9,12 +9,7 @@ export default function EmptyState({ icon }: EmptyStateProps) {
     <S.EmptyState>
       <S.Icon>{icon}</S.Icon>
       <S.MessageWrapper>
-        <S.MainMessage>비어있어요</S.MainMessage>
-        <S.Description>
-          코그룸은 코그니어 유저들과의 보다 원활한
-          <br />
-          활동을 위해 열심히 노력하고 있어요
-        </S.Description>
+        <S.MainMessage>X</S.MainMessage>
       </S.MessageWrapper>
     </S.EmptyState>
   );

--- a/src/components/organisms/Modal/Signup/Signup.tsx
+++ b/src/components/organisms/Modal/Signup/Signup.tsx
@@ -40,12 +40,7 @@ export default function Signup({ provider, providerId, email, nickname }: Signup
         />
       )}
 
-      {step === SIGNUP_STEP.INPUT_NEW_EMAIL && (
-        <InputEmail
-          email={email}
-          onConfirm={() => setStep(SIGNUP_STEP.VERIFY_EMAIL)}
-        />
-      )}
+      {step === SIGNUP_STEP.INPUT_NEW_EMAIL && <InputEmail onConfirm={() => setStep(SIGNUP_STEP.VERIFY_EMAIL)} />}
 
       {step === SIGNUP_STEP.VERIFY_EMAIL && (
         <VerifyEmail

--- a/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/CheckEmail/CheckEmail.tsx
@@ -41,7 +41,7 @@ export default function CheckEmail({ email, onConfirm, onChangeEmail }: CheckEma
 
       <S.ButtonWrapper>
         <SolidButton
-          label='이 이메일로 시작하기'
+          label='맞아요'
           size='md'
           color='primary'
           interactionVariant='normal'
@@ -49,7 +49,7 @@ export default function CheckEmail({ email, onConfirm, onChangeEmail }: CheckEma
           fillContainer
         />
         <OutlinedButton
-          label='다른 이메일 사용하기'
+          label='다른 이메일 쓸게요'
           size='md'
           color='assistive'
           interactionVariant='normal'

--- a/src/components/organisms/Modal/Signup/Steps/InputEmail/InputEmail.tsx
+++ b/src/components/organisms/Modal/Signup/Steps/InputEmail/InputEmail.tsx
@@ -11,11 +11,10 @@ import { validateEmail } from '@/utils/validators/userValidators';
 import * as S from './InputEmail.styled';
 
 export interface InputEmailProps {
-  email: string;
   onConfirm: () => void;
 }
 
-export default function InputEmail({ email, onConfirm }: InputEmailProps) {
+export default function InputEmail({ onConfirm }: InputEmailProps) {
   const {
     register,
     handleSubmit,
@@ -41,7 +40,7 @@ export default function InputEmail({ email, onConfirm }: InputEmailProps) {
         <Input
           label='이메일'
           inputSize='md'
-          placeholder={email}
+          placeholder='cognier@cogroom.com'
           {...register('email', {
             required: VALIDATION_MESSAGE.EMAIL_EMPTY_FILED_ERROR,
             validate: validateEmail,

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -171,3 +171,5 @@ export const ROLE_OPTIONS: RoleKey[] = ['ADMIN', 'USER', 'CONTENT_PROVIDER'];
 export const SPRITE_WIDTH = 257;
 export const FRAME_COUNT = 9;
 export const FRAME_DURATION = 800;
+export const DAILY_MAX_LENGTH = 101;
+

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -172,4 +172,3 @@ export const SPRITE_WIDTH = 257;
 export const FRAME_COUNT = 9;
 export const FRAME_DURATION = 800;
 export const DAILY_MAX_LENGTH = 101;
-

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -63,7 +63,7 @@ export const DEFAULT_DAILY_QUESTION = '내가 생각하는 ‘나’는 어떤 �
 
 export const COGPOINT_CARDS = [
   {
-    icon: HandHeart,
+    icon: Smile,
     subtitle: 'for self growth',
     title: '나보다 나를 더 잘 아는\n자기이해 플랫폼',
     content: '무의식적으로 해온 생각과 나도 몰랐던 나의 마음들을 알아차려요',
@@ -75,10 +75,10 @@ export const COGPOINT_CARDS = [
     content: '단순한 학습이 아닌, 과학적 학문 기반으로',
   },
   {
-    icon: Smile,
-    subtitle: 'for self growth',
-    title: '나보다 나를 더 잘 아는\n자기이해 플랫폼',
-    content: '무의식적으로 해온 생각과 나도 몰랐던 나의 마음들을 알아차려요',
+    icon: HandHeart,
+    subtitle: 'droplet to ocean',
+    title: '한 방울씩 성찰이 쌓여\n내면의 깊은 바다로',
+    content: '매일 질문에 답하고, 지식을 쌓으며, 함께 소통하고 성장해요',
   },
 ];
 

--- a/src/hooks/api/daily/useEditDailyAnswer.ts
+++ b/src/hooks/api/daily/useEditDailyAnswer.ts
@@ -20,13 +20,13 @@ export const useEditDailyAnswerMutation = () => {
     onError: (error: HTTPError) => {
       switch (error.code) {
         case 'ANSWER_NOTBLANK_ERROR':
-          open('error', { message: '한 글자라도 적어주세요' });
+          open('alert', { message: '한 글자라도 적어주세요' });
           break;
         case 'ANSWER_SIZE_ERROR':
-          open('error', { message: '내용을 조금만 줄여볼까요?' });
+          open('alert', { message: '내용을 조금만 줄여볼까요?' });
           break;
         case 'ANSWER_TIME_EXPIRED':
-          open('error', { message: '앗.. 자정이 지나 수정할 수 없어요' });
+          open('alert', { message: '앗.. 자정이 지나 수정할 수 없어요' });
           break;
         default:
           open('error', { message: error.message });

--- a/src/hooks/api/daily/useSubmitDailyAnswer.ts
+++ b/src/hooks/api/daily/useSubmitDailyAnswer.ts
@@ -23,13 +23,13 @@ export const useSubmitDailyAnswerMutation = () => {
     onError: (error: HTTPError) => {
       switch (error.code) {
         case 'ANSWER_NOTBLANK_ERROR':
-          openAlert('error', { message: '한 글자라도 적어주세요' });
+          openAlert('alert', { message: '한 글자라도 적어주세요' });
           break;
         case 'ANSWER_SIZE_ERROR':
-          openAlert('error', { message: '내용을 조금만 줄여볼까요?' });
+          openAlert('alert', { message: '내용을 조금만 줄여볼까요?' });
           break;
         case 'ANSWER_TIME_EXPIRED':
-          openAlert('error', { message: '앗.. 자정이 지나 수정할 수 없어요' });
+          openAlert('alert', { message: '앗.. 자정이 지나 수정할 수 없어요' });
           break;
         default:
           openAlert('error', { message: error.message });

--- a/src/hooks/useShake.ts
+++ b/src/hooks/useShake.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useShake() {
+  const [isShaking, setIsShaking] = useState(false);
+
+  const triggerShake = useCallback(() => {
+    setIsShaking(true);
+  }, []);
+
+  useEffect(() => {
+    if (isShaking) {
+      const timeout = setTimeout(() => setIsShaking(false), 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [isShaking]);
+
+  return { isShaking, triggerShake };
+}

--- a/src/hooks/useTextLimiter.ts
+++ b/src/hooks/useTextLimiter.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+import { useShake } from './useShake';
+
+export function useTextLimiter(maxLength: number, initialValue: string = '') {
+  const [value, setValue] = useState(initialValue);
+  const { isShaking, triggerShake } = useShake();
+
+  useEffect(() => {
+    if (value.length > maxLength) {
+      setValue(value.slice(0, maxLength));
+      triggerShake();
+    }
+  }, [value, maxLength, triggerShake]);
+
+  return {
+    value,
+    setValue,
+    isShaking,
+    isOverLimit: value.length >= maxLength,
+  };
+}

--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -1,0 +1,17 @@
+import { css, keyframes } from '@emotion/react';
+
+export const shake = keyframes`
+  0% { transform: translateX(0); }
+  12.5% { transform: translateX(-2px); }
+  25% { transform: translateX(0); }
+  37.5% { transform: translateX(2px); }
+  50% { transform: translateX(0); }
+  62.5% { transform: translateX(-2px); }
+  75% { transform: translateX(0); }
+  87.5% { transform: translateX(2px); }
+  100% { transform: translateX(0); }
+`;
+
+export const shakeAnimation = css`
+  animation: ${shake} 0.3s ease-in-out;
+`;


### PR DESCRIPTION
`release/0.2.1` 브랜치에서 릴리즈된 변경사항을 `develop` 브랜치에도 반영하기 위한 머지 PR입니다.

## ✅ 포함된 변경 사항

- [FEAT] 어드민 가드의 '홈으로 가기' 버튼 제거 확인 (#225)
- [FEAT] 마이페이지 알림 디자인 수정 적용 확인 (#257)
- [FEAT] 회원가입 단계 문구 수정 적용 확인 (#259)
- [FEAT] 데일리 유효성 에러모달 서브문구 제거 확인 (#261)
- [FIX] 캐러셀 카드 PDF 뱃지 미표시 버그 수정 확인 (#266)
- [FEAT] '비어있어요' 문구 변경 확인 (#263)
- [FEAT] 100자 이상 입력 시 효과 정상 반영 확인 (#265)
- [FIX] 홈 페이지 문구 수정 반영 확인 (#271)

## 🧾 관련 이슈 및 PR

- 0.2.0 QA 이슈: #270 
