### PR TITLE
[FEAT] 어드민 게시글/댓글 삭제 구현 #466

### DIFF
--- a/src/api/commentApis.ts
+++ b/src/api/commentApis.ts
@@ -1,0 +1,18 @@
+import { AxiosResponse } from 'axios';
+
+import { END_POINTS_V1 } from '@/constants/api';
+import { ApiResponse } from '@/types/api';
+
+import { axiosInstance } from './axios/axiosInstance';
+
+const deleteComment = async ({ commentId }: { commentId: string }) => {
+  const { data } = await axiosInstance.delete<null, AxiosResponse<ApiResponse>>(
+    END_POINTS_V1.COMMENTS.DELETE(commentId),
+  );
+
+  return data;
+};
+
+export const commentApi = {
+  deleteComment,
+};

--- a/src/api/postApis.ts
+++ b/src/api/postApis.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 
 import { END_POINTS_V1 } from '@/constants/api';
+import { ApiResponse } from '@/types/api';
 import { CreatePostRequest, CreatePostResponse } from '@/types/post';
 
 import { axiosInstance } from './axios/axiosInstance';
@@ -20,6 +21,13 @@ const createPost = async ({ title, categoryId, content, isAnonymous, imageUrlLis
   return data.result;
 };
 
+const deletePost = async ({ postId }: { postId: string }) => {
+  const { data } = await axiosInstance.delete<null, AxiosResponse<ApiResponse>>(END_POINTS_V1.POSTS.DELETE(postId));
+
+  return data;
+};
+
 export const postApi = {
   createPost,
+  deletePost,
 };

--- a/src/app/(shared)/(standard)/admin/community/_components/CommunityListRow/CommunityListRow.styled.ts
+++ b/src/app/(shared)/(standard)/admin/community/_components/CommunityListRow/CommunityListRow.styled.ts
@@ -94,3 +94,15 @@ export const CreatedAt = styled.p`
   width: 10rem;
   text-align: center;
 `;
+
+export const DropdownContainer = styled.div`
+  position: relative;
+`;
+
+export const DropdownWrapper = styled.div`
+  position: absolute;
+  left: -12rem;
+  bottom: -6rem;
+
+  width: 15rem;
+`;

--- a/src/app/(shared)/(standard)/admin/community/_components/CommunityListRow/CommunityListRow.tsx
+++ b/src/app/(shared)/(standard)/admin/community/_components/CommunityListRow/CommunityListRow.tsx
@@ -10,6 +10,7 @@ import { POST_CATEGORY_META } from '@/constants/common';
 import { useDeleteCommentMutation } from '@/hooks/api/comment/useDeleteComment';
 import { useDeletePostMutation } from '@/hooks/api/post/useDeletePost';
 import { useDropdown } from '@/hooks/useDropdown';
+import { useAlertModalStore } from '@/stores/useModalStore';
 import { Comment, CommentStatus } from '@/types/comment';
 import { DropdownOption } from '@/types/common';
 import { Post, PostStatus } from '@/types/post';
@@ -23,8 +24,7 @@ export type CommunityListRowProps = { type: 'post'; post: Post } | { type: 'comm
 const DROPDOWN_OPTIONS: DropdownOption[] = [{ label: '삭제하기', value: 'DELETE', color: 'default' }];
 
 export default function CommunityListRow(props: CommunityListRowProps) {
-  const { deletePost } = useDeletePostMutation();
-  const { deleteComment } = useDeleteCommentMutation();
+  const { open } = useAlertModalStore();
 
   const isPost = props.type === 'post';
 
@@ -54,13 +54,11 @@ export default function CommunityListRow(props: CommunityListRowProps) {
   const handleDropdownSelect = (values: Array<string | number>) => {
     const v = values[0];
     if (v === 'DELETE') {
-      if (isPost) {
-        deletePost({ postId: String(id) });
-      } else {
-        deleteComment({ commentId: String(id) });
-      }
-      close();
+      const targetType = isPost ? 'post' : 'comment';
+      open('communityDelete', { type: targetType, id });
     }
+
+    close();
   };
 
   return (

--- a/src/components/atoms/DropdownItem/DropdownItem.styled.ts
+++ b/src/components/atoms/DropdownItem/DropdownItem.styled.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { SerializedStyles, css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { Theme } from '@/styles/theme';
+
+export type DropdownItemColor = 'default' | 'red';
+
+export interface DropdownItemStyleProps {
+  color: DropdownItemColor;
+}
+
+const colorStyles: Record<DropdownItemColor, (theme: Theme) => SerializedStyles> = {
+  default: (theme) => css`
+    color: ${theme.semantic.label.normal};
+  `,
+
+  red: (theme) => css`
+    color: ${theme.semantic.status.destructive};
+  `,
+};
+
+export const DropdownItem = styled.div<DropdownItemStyleProps>`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  width: 100%;
+  padding: 1.2rem 1.6rem;
+  border-radius: 1.2rem;
+
+  ${({ theme }) => theme.typography.body1.regular};
+  ${({ theme, color }) => colorStyles[color](theme)};
+  background-color: ${({ theme }) => theme.semantic.static.white};
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background-color: ${({ theme }) => theme.semantic.background.elevated.normal};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/components/atoms/DropdownItem/DropdownItem.tsx
+++ b/src/components/atoms/DropdownItem/DropdownItem.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import * as S from './DropdownItem.styled';
+import type { DropdownItemStyleProps } from './DropdownItem.styled';
+
+interface DropdownItemProps extends DropdownItemStyleProps {
+  label: string;
+  value: string | number;
+  isChecked: boolean;
+  onToggle: (value: string | number, checked: boolean) => void;
+}
+
+export function DropdownItem({ label, value, isChecked, onToggle, color = 'default' }: DropdownItemProps) {
+  const handleClick = () => {
+    onToggle(value, !isChecked);
+  };
+
+  return (
+    <S.DropdownItem
+      tabIndex={0}
+      color={color}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      {label}
+    </S.DropdownItem>
+  );
+}

--- a/src/components/molecules/DropdownList/DropdownList.styled.ts
+++ b/src/components/molecules/DropdownList/DropdownList.styled.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const DropdownList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  padding: 0.4rem 0.8rem;
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.semantic.static.white};
+
+  ${({ theme }) => theme.shadow.normal};
+`;

--- a/src/components/molecules/DropdownList/DropdownList.tsx
+++ b/src/components/molecules/DropdownList/DropdownList.tsx
@@ -1,0 +1,31 @@
+import { DropdownItem } from '@/components/atoms/DropdownItem/DropdownItem';
+import { DropdownOption } from '@/types/common';
+
+import * as S from './DropdownList.styled';
+
+interface DropdownListProps {
+  options: DropdownOption[];
+  selectedValues: Array<string | number>;
+  onSelect: (value: Array<string | number>) => void;
+}
+
+export function DropdownList({ options, selectedValues, onSelect }: DropdownListProps) {
+  const handleToggle = (value: string | number) => {
+    onSelect([value]);
+  };
+
+  return (
+    <S.DropdownList>
+      {options.map((option) => (
+        <DropdownItem
+          key={`${option.label}-${option.value}`}
+          color={option.color}
+          label={option.label}
+          value={option.value}
+          isChecked={selectedValues.includes(option.value)}
+          onToggle={handleToggle}
+        />
+      ))}
+    </S.DropdownList>
+  );
+}

--- a/src/components/organisms/Modal/CommunityDelete/CommunityDelete.styled.ts
+++ b/src/components/organisms/Modal/CommunityDelete/CommunityDelete.styled.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const CommunityDelete = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+
+  width: 100%;
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.headline1.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 1.2rem;
+`;

--- a/src/components/organisms/Modal/CommunityDelete/CommunityDelete.tsx
+++ b/src/components/organisms/Modal/CommunityDelete/CommunityDelete.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
+import SolidButton from '@/components/atoms/SolidButton/SolidButton';
+import { useDeleteCommentMutation } from '@/hooks/api/comment/useDeleteComment';
+import { useDeletePostMutation } from '@/hooks/api/post/useDeletePost';
+import { useAlertModalStore } from '@/stores/useModalStore';
+
+import * as S from './CommunityDelete.styled';
+
+export interface CommunityDeleteProps {
+  type: 'post' | 'comment';
+  id: number;
+}
+
+export default function CommunityDelete({ type, id }: CommunityDeleteProps) {
+  const { close } = useAlertModalStore();
+  const { deletePost } = useDeletePostMutation();
+  const { deleteComment } = useDeleteCommentMutation();
+
+  const isPost = type === 'post';
+
+  const handleConfirm = () => {
+    if (isPost) {
+      deletePost({ postId: String(id) });
+    } else {
+      deleteComment({ commentId: String(id) });
+    }
+    close();
+  };
+
+  const handleCancel = () => {
+    close();
+  };
+
+  return (
+    <S.CommunityDelete>
+      <S.Title>{isPost ? '글을 삭제하시겠습니까?' : '댓글을 삭제하시겠습니까?'}</S.Title>
+
+      <S.ButtonWrapper>
+        <OutlinedButton
+          label='취소'
+          size='sm'
+          color='assistive'
+          interactionVariant='normal'
+          onClick={handleCancel}
+          fillContainer
+        />
+        <SolidButton
+          label='확인'
+          size='sm'
+          color='primary'
+          interactionVariant='normal'
+          onClick={handleConfirm}
+          fillContainer
+        />
+      </S.ButtonWrapper>
+    </S.CommunityDelete>
+  );
+}

--- a/src/components/organisms/Modal/modalConfig.ts
+++ b/src/components/organisms/Modal/modalConfig.ts
@@ -2,6 +2,7 @@ import type { ModalMap } from '@/types/modal';
 
 import Alert, { AlertProps } from './Alert/Alert';
 import ChangeRole, { ChangeRoleProps } from './ChangeRole/ChangeRole';
+import CommunityDelete, { CommunityDeleteProps } from './CommunityDelete/CommunityDelete';
 import DailyShare, { DailyShareProps } from './Daily/DailyShare/DailyShare';
 import DailyFirstAnswer, { DailyFirstAnswerProps } from './Daily/FirstAnswer/DailyFirstAnswer';
 import DailyAnswerPost, { DailyAnswerPostProps } from './Daily/Post/DailyAnswerPost';
@@ -27,6 +28,7 @@ export type AlertModalProps = {
   alert: AlertProps;
   dailyFirstAnswer: DailyFirstAnswerProps;
   changeRole: ChangeRoleProps;
+  communityDelete: CommunityDeleteProps;
 };
 
 export const AppModalRegistry = {
@@ -44,4 +46,5 @@ export const AlertModalRegistry = {
   alert: { Component: Alert, disableOutsideClick: false },
   dailyFirstAnswer: { Component: DailyFirstAnswer, disableOutsideClick: false },
   changeRole: { Component: ChangeRole, disableOutsideClick: false },
+  communityDelete: { Component: CommunityDelete, disableOutsideClick: false },
 } satisfies ModalMap<AlertModalProps>;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -81,6 +81,8 @@ export const END_POINTS_V1 = {
   },
   POSTS: {
     CREATE: `${BASE_PATH_V1.POSTS}`,
+    DELETE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}`,
+  },
   COMMENTS: {
     DELETE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}`,
   },

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -13,6 +13,7 @@ const BASE_PATH_V1 = {
   FILE: `${API_V1}/files`,
   STREAKS: `${API_V1}/streaks`,
   POSTS: `${API_V1}/posts`,
+  COMMENTS: `${API_V1}/comments`,
 
   ADMIN: `${API_V1}/admin`,
 } as const;
@@ -80,6 +81,8 @@ export const END_POINTS_V1 = {
   },
   POSTS: {
     CREATE: `${BASE_PATH_V1.POSTS}`,
+  COMMENTS: {
+    DELETE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}`,
   },
 
   ADMIN: {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -39,6 +39,7 @@ const ADMIN_QUERY_KEYS = {
   ADMIN_DAILY_LIST: ['admin', 'daily_list'],
   ADMIN_MEMBER_DAILY: ['admin', 'daily'],
   POST_LIST: ['admin', 'post_list'],
+  COMMENT_LIST: ['admin', 'comment_list'],
 } as const;
 
 export { AUTH_QUERY_KEYS, MEMBER_QUERY_KEYS, DAILY_QUERY_KEYS, STREAK_QUERY_KEYS, POST_QUERY_KEYS, ADMIN_QUERY_KEYS };

--- a/src/hooks/api/comment/useDeleteComment.ts
+++ b/src/hooks/api/comment/useDeleteComment.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { commentApi } from '@/api/commentApis';
+import { ADMIN_QUERY_KEYS } from '@/constants/queryKeys';
+
+export const useDeleteCommentMutation = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: commentApi.deleteComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...ADMIN_QUERY_KEYS.COMMENT_LIST] });
+      // TODO: 댓글 목록 조회도 캐시 무효화 (추후 Optimistic Update로 개선)
+    },
+  });
+
+  return { deleteComment: mutation.mutate };
+};

--- a/src/hooks/api/comment/useDeleteComment.ts
+++ b/src/hooks/api/comment/useDeleteComment.ts
@@ -4,15 +4,36 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { commentApi } from '@/api/commentApis';
 import { ADMIN_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAlertModalStore } from '@/stores/useModalStore';
+import { HTTPError } from '@/api/axios/errors/HTTPError';
 
 export const useDeleteCommentMutation = () => {
   const queryClient = useQueryClient();
+  const { open } = useAlertModalStore();
 
   const mutation = useMutation({
     mutationFn: commentApi.deleteComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...ADMIN_QUERY_KEYS.COMMENT_LIST] });
       // TODO: 댓글 목록 조회도 캐시 무효화 (추후 Optimistic Update로 개선)
+      open('alert', { message: '댓글이 삭제되었습니다.' });
+    },
+
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'COMMENT_FORBIDDEN_ERROR':
+          open('alert', { message: '본인이 작성한 댓글만 수정/삭제가 가능합니다.' });
+          break;
+        case 'COMMENT_ALREADY_DELETED_ERROR':
+          open('alert', { message: '이미 삭제된 댓글입니다.' });
+          break;
+        case 'COMMENT_HIDDEN_ERROR':
+          open('alert', { message: '숨김 처리된 댓글입니다.' });
+          break;
+        default:
+          open('alert', { message: '댓글 삭제에 실패했습니다.' });
+          break;
+      }
     },
   });
 

--- a/src/hooks/api/post/useDeletePost.ts
+++ b/src/hooks/api/post/useDeletePost.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postApi } from '@/api/postApis';
+import { ADMIN_QUERY_KEYS } from '@/constants/queryKeys';
+
+export const useDeletePostMutation = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: postApi.deletePost,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...ADMIN_QUERY_KEYS.POST_LIST] });
+      // TODO: 게시글 목록 조회도 캐시 무효화 (추후 Optimistic Update로 개선)
+    },
+  });
+
+  return { deletePost: mutation.mutate };
+};

--- a/src/hooks/api/post/useDeletePost.ts
+++ b/src/hooks/api/post/useDeletePost.ts
@@ -4,15 +4,35 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { postApi } from '@/api/postApis';
 import { ADMIN_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAlertModalStore } from '@/stores/useModalStore';
+import { HTTPError } from '@/api/axios/errors/HTTPError';
 
 export const useDeletePostMutation = () => {
   const queryClient = useQueryClient();
+  const { open } = useAlertModalStore();
 
   const mutation = useMutation({
     mutationFn: postApi.deletePost,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...ADMIN_QUERY_KEYS.POST_LIST] });
       // TODO: 게시글 목록 조회도 캐시 무효화 (추후 Optimistic Update로 개선)
+      open('alert', { message: '글이 삭제되었습니다.' });
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'POST_FORBIDDEN_ERROR':
+          open('alert', { message: '본인이 작성한 게시글만 수정/삭제가 가능합니다.' });
+          break;
+        case 'POST_ALREADY_DELETED_ERROR':
+          open('alert', { message: '이미 삭제된 게시글입니다.' });
+          break;
+        case 'POST_HIDDEN_ERROR':
+          open('alert', { message: '숨김 처리된 게시글입니다.' });
+          break;
+        default:
+          open('alert', { message: '글 삭제에 실패했습니다.' });
+          break;
+      }
     },
   });
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,8 +1,15 @@
+import { DropdownItemColor } from '@/components/atoms/DropdownItem/DropdownItem.styled';
 import { Align, ColumnMode } from '@/components/organisms/Table/TableHeader/TableHeader.styled';
 
 export interface SelectOption {
   label: string;
   value: string | number;
+}
+
+export interface DropdownOption {
+  label: string;
+  value: string | number;
+  color: DropdownItemColor;
 }
 
 export interface TableHeaderItem {

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,3 +1,5 @@
+import { ApiResponse } from './api';
+
 export type PostStatus = 'ACTIVE' | 'DELETED_BY_USER' | 'DELETED_BY_ADMIN' | 'USER_WITHDRAWN';
 
 export interface PostSummary {
@@ -47,6 +49,6 @@ export type CreatePostRequest = {
   imageUrlList: string[];
 };
 
-export interface CreatePostResponse {
+export interface CreatePostResponse extends ApiResponse {
   result: Post;
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #466

## 📋 작업 내용

- 게시글, 댓글 삭제 구현
-> 삭제 하실때 CommunityDelete 모달만 open 하고 type이랑 id만 넘겨주시면 됩니다!

- DropdownItem 컴포넌트 추가

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)

모달 관련해서 한번 싹 정리해야할 것 같아요ㅠㅠ 일단 에러처리는 다 alert로 해두었습니다!