### PR TITLE
[FEAT] 커뮤니티 > 글 수정페이지 추가 #446

### DIFF
--- a/src/api/postApis.ts
+++ b/src/api/postApis.ts
@@ -31,7 +31,7 @@ const createPost = async ({ title, categoryId, content, isAnonymous, imageUrlLis
 
 const updatePost = async (
   postId: string,
-  { title, categoryId, content, imageUrlList, deleteUrlList }: UpdatePostRequest,
+  { title, categoryId, content, isAnonymous, imageUrlList, deleteUrlList }: UpdatePostRequest,
 ) => {
   const { data } = await axiosInstance.patch<UpdatePostRequest, AxiosResponse<UpdatePostResponse>>(
     END_POINTS_V1.POSTS.POST_UPDATE(postId),
@@ -39,6 +39,7 @@ const updatePost = async (
       title,
       categoryId,
       content,
+      isAnonymous,
       imageUrlList,
       deleteUrlList,
     },

--- a/src/api/postApis.ts
+++ b/src/api/postApis.ts
@@ -2,7 +2,15 @@ import type { AxiosResponse } from 'axios';
 
 import { END_POINTS_V1 } from '@/constants/api';
 import { ApiResponse } from '@/types/api';
-import { CreatePostRequest, CreatePostResponse, PostListRequest, PostListResponse, PostResponse } from '@/types/post';
+import {
+  CreatePostRequest,
+  CreatePostResponse,
+  PostListRequest,
+  PostListResponse,
+  PostResponse,
+  UpdatePostRequest,
+  UpdatePostResponse,
+} from '@/types/post';
 
 import { axiosInstance } from './axios/axiosInstance';
 
@@ -15,6 +23,24 @@ const createPost = async ({ title, categoryId, content, isAnonymous, imageUrlLis
       content,
       isAnonymous,
       imageUrlList,
+    },
+  );
+
+  return data.result;
+};
+
+const updatePost = async (
+  postId: string,
+  { title, categoryId, content, imageUrlList, deleteUrlList }: UpdatePostRequest,
+) => {
+  const { data } = await axiosInstance.patch<UpdatePostRequest, AxiosResponse<UpdatePostResponse>>(
+    END_POINTS_V1.POSTS.POST_UPDATE(postId),
+    {
+      title,
+      categoryId,
+      content,
+      imageUrlList,
+      deleteUrlList,
     },
   );
 
@@ -67,6 +93,7 @@ const deletePost = async ({ postId }: { postId: string }) => {
 
 export const postApi = {
   createPost,
+  updatePost,
   getPost,
   getPostList,
   togglePostLike,

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostAuthor/PostAuthor.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostAuthor/PostAuthor.tsx
@@ -1,9 +1,7 @@
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
-import DotsVerticalIcon from '@/assets/icons/dots-vertical.svg';
 import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
-import IconButton from '@/components/atoms/IconButton/IconButton';
 import { useAlertModalStore, useSimpleModalStore } from '@/stores/useModalStore';
 import { getDisplayName } from '@/utils/formatText';
 
@@ -27,7 +25,7 @@ export default function PostAuthor({ author, postId, isMine = false, isAdmin = f
   const { open: openAlert } = useAlertModalStore();
   const { open: openSimpleModal } = useSimpleModalStore();
 
-  const canEdit = isMine && !author.isAnonymous; // 익명 게시글은 수정 불가
+  const canEdit = isMine && !author.isAnonymous;
   const canDelete = isMine || isAdmin;
 
   const handleMenuClick = () => {

--- a/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.styled.ts
+++ b/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.styled.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const CategoryBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+`;
+
+export const CategorySelect = styled.div`
+  width: 15rem;
+`;
+
+export const AnonymousCheckbox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 1.4rem;
+  color: ${({ theme }) => theme.semantic.label.normal};
+
+  label {
+    cursor: pointer;
+    user-select: none;
+  }
+`;
+
+export const CheckboxWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+`;
+
+export const CheckboxName = styled.span`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;

--- a/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.tsx
+++ b/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.tsx
@@ -1,0 +1,84 @@
+import { Controller, Control } from 'react-hook-form';
+
+import Checkbox from '@/components/atoms/Checkbox/Checkbox';
+import { Select } from '@/components/molecules/Select/Select';
+import { CategorySelectorProps, FormControl } from '@/types/communityWrite';
+
+import * as S from './CategorySelector.styled';
+
+export default function CategorySelector({
+  options,
+  error,
+  onChange,
+  onCategoryChange,
+  showAnonymous,
+  onAnonymousToggle,
+  control,
+}: Omit<CategorySelectorProps, 'value'> & {
+  showAnonymous: boolean;
+  onAnonymousToggle: (checked: boolean) => void;
+  control: FormControl;
+}) {
+  return (
+    <S.CategoryBox>
+      <S.CategorySelect>
+        <Controller
+          name='categoryId'
+          control={control}
+          rules={{ required: '카테고리를 선택해 주세요.' }}
+          render={({ field }) => (
+            <Select
+              inputSize='md'
+              label='카테고리'
+              placeholder='카테고리 선택'
+              options={options}
+              value={field.value || []}
+              error={error}
+              onChange={(val) => {
+                const numericVal = Array.isArray(val)
+                  ? val.map((v) => (typeof v === 'string' ? parseInt(v, 10) : v))
+                  : typeof val === 'string'
+                    ? parseInt(val, 10)
+                    : val;
+
+                const numericArray = Array.isArray(numericVal) ? numericVal : [numericVal];
+
+                field.onChange(numericArray);
+                onChange(numericArray);
+
+                const categoryValue = numericArray[0];
+                if (categoryValue) {
+                  onCategoryChange(categoryValue);
+                }
+              }}
+            />
+          )}
+        />
+      </S.CategorySelect>
+
+      {showAnonymous && (
+        <S.AnonymousCheckbox>
+          <Controller
+            name='isAnonymous'
+            control={control}
+            render={({ field }) => (
+              <S.CheckboxWrapper>
+                <Checkbox
+                  size='nm'
+                  isChecked={field.value}
+                  onToggle={(checked) => {
+                    field.onChange(checked);
+                    onAnonymousToggle(checked);
+                  }}
+                  interactionVariant='normal'
+                  name='isAnonymous'
+                />
+                <S.CheckboxName>익명</S.CheckboxName>
+              </S.CheckboxWrapper>
+            )}
+          />
+        </S.AnonymousCheckbox>
+      )}
+    </S.CategoryBox>
+  );
+}

--- a/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.tsx
+++ b/src/app/(shared)/(standard)/community/write/_components/CategorySelector/CategorySelector.tsx
@@ -14,10 +14,12 @@ export default function CategorySelector({
   showAnonymous,
   onAnonymousToggle,
   control,
+  isAnonymousDisabled = false,
 }: Omit<CategorySelectorProps, 'value'> & {
   showAnonymous: boolean;
   onAnonymousToggle: (checked: boolean) => void;
   control: FormControl;
+  isAnonymousDisabled?: boolean;
 }) {
   return (
     <S.CategoryBox>
@@ -67,10 +69,13 @@ export default function CategorySelector({
                   size='nm'
                   isChecked={field.value}
                   onToggle={(checked) => {
-                    field.onChange(checked);
-                    onAnonymousToggle(checked);
+                    if (!isAnonymousDisabled) {
+                      field.onChange(checked);
+                      onAnonymousToggle(checked);
+                    }
                   }}
                   interactionVariant='normal'
+                  isDisabled={isAnonymousDisabled}
                   name='isAnonymous'
                 />
                 <S.CheckboxName>익명</S.CheckboxName>

--- a/src/app/(shared)/(standard)/community/write/_components/DailyQuestionCard/DailyQuestionCard.tsx
+++ b/src/app/(shared)/(standard)/community/write/_components/DailyQuestionCard/DailyQuestionCard.tsx
@@ -1,0 +1,20 @@
+import Question from '@/app/(shared)/(standard)/daily/_components/Question/Question';
+import { DEFAULT_DAILY_QUESTION } from '@/constants/common';
+import { DailyQuestionCardProps } from '@/types/communityWrite';
+
+export default function DailyQuestionCard({ question, answer, assignedQuestionId = 0 }: DailyQuestionCardProps) {
+  if (!question || !answer) {
+    return null;
+  }
+
+  return (
+    <Question
+      assignedQuestionId={assignedQuestionId}
+      question={question || DEFAULT_DAILY_QUESTION}
+      answer={answer}
+      hasAnswered={true}
+      hideSubmitButton={true}
+      readOnlyMode={true}
+    />
+  );
+}

--- a/src/app/(shared)/(standard)/community/write/_components/PostEditor/PostEditor.styled.ts
+++ b/src/app/(shared)/(standard)/community/write/_components/PostEditor/PostEditor.styled.ts
@@ -1,0 +1,9 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const ContentSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+`;

--- a/src/app/(shared)/(standard)/community/write/_components/PostEditor/PostEditor.tsx
+++ b/src/app/(shared)/(standard)/community/write/_components/PostEditor/PostEditor.tsx
@@ -1,0 +1,34 @@
+import { Controller } from 'react-hook-form';
+
+import Editor from '@/components/organisms/Editor/Editor';
+import { PostEditorProps, FormControl } from '@/types/communityWrite';
+
+import * as S from './PostEditor.styled';
+
+export default function PostEditor({
+  control,
+  onContentChange,
+  height = 800,
+}: PostEditorProps & {
+  control: FormControl;
+  onContentChange: (value: string) => void;
+}) {
+  return (
+    <Controller
+      name='content'
+      control={control}
+      render={({ field }) => (
+        <S.ContentSection>
+          <Editor
+            value={field.value || ''}
+            onChange={(val) => {
+              field.onChange(val);
+              onContentChange(val);
+            }}
+            height={height}
+          />
+        </S.ContentSection>
+      )}
+    />
+  );
+}

--- a/src/app/(shared)/(standard)/community/write/_components/TitleInput/TitleInput.tsx
+++ b/src/app/(shared)/(standard)/community/write/_components/TitleInput/TitleInput.tsx
@@ -1,0 +1,36 @@
+import { Controller } from 'react-hook-form';
+
+import Input from '@/components/molecules/Input/Input';
+import { FormControl } from '@/types/communityWrite';
+
+export default function TitleInput({ control, error }: { control: FormControl; error?: string }) {
+  return (
+    <Controller
+      name='title'
+      control={control}
+      rules={{
+        required: '제목을 입력해 주세요.',
+        maxLength: {
+          value: 30,
+          message: '제목은 최대 30자까지 입력할 수 있어요.',
+        },
+        validate: (value) => {
+          // 허용 문자 정규식 (한글, 영문, 숫자, 특수문자, 이모지 포함)
+          const allowedRegex = /^[\p{L}\p{N}\p{P}\p{S}\p{Emoji}\s]+$/u;
+
+          return allowedRegex.test(value) || '제목에 사용할 수 없는 문자가 있어요';
+        },
+      }}
+      render={({ field }) => (
+        <Input
+          inputSize='lg'
+          label='제목'
+          placeholder='제목을 입력해 주세요.'
+          value={field.value || ''}
+          onChange={(val) => field.onChange(val)}
+          error={error}
+        />
+      )}
+    />
+  );
+}

--- a/src/app/(shared)/(standard)/community/write/page.tsx
+++ b/src/app/(shared)/(standard)/community/write/page.tsx
@@ -43,6 +43,7 @@ export default function CommunityWrite() {
             showAnonymous={logic.showAnonymous}
             onAnonymousToggle={(checked: boolean) => logic.methods.setValue('isAnonymous', checked)}
             control={logic.methods.control}
+            isAnonymousDisabled={logic.isAnonymousDisabled}
           />
 
           <TitleInput

--- a/src/app/(shared)/(standard)/community/write/page.tsx
+++ b/src/app/(shared)/(standard)/community/write/page.tsx
@@ -1,134 +1,26 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect } from 'react';
-import { Controller, FormProvider, useForm } from 'react-hook-form';
+import { FormProvider } from 'react-hook-form';
 
-import Question from '@/app/(shared)/(standard)/daily/_components/Question/Question';
-import Checkbox from '@/components/atoms/Checkbox/Checkbox';
 import SolidButton from '@/components/atoms/SolidButton/SolidButton';
 import Breadcrumb from '@/components/molecules/Breadcrumb/Breadcrumb';
-import Input from '@/components/molecules/Input/Input';
-import { Select } from '@/components/molecules/Select/Select';
-import Editor from '@/components/organisms/Editor/Editor';
-import { DEFAULT_DAILY_QUESTION } from '@/constants/common';
-import useGetDailyQuestionsQuery from '@/hooks/api/daily/useGetDailyQuestions';
-import { useCreatePostMutation } from '@/hooks/api/post/useCreatePost';
-import { useAlertModalStore } from '@/stores/useModalStore';
+import Loading from '@/components/organisms/Loading/Loading';
+import { useCommunityWriteLogic } from '@/hooks/useCommunityWriteLogic';
 
+import CategorySelector from './_components/CategorySelector/CategorySelector';
+import DailyQuestionCard from './_components/DailyQuestionCard/DailyQuestionCard';
+import PostEditor from './_components/PostEditor/PostEditor';
+import TitleInput from './_components/TitleInput/TitleInput';
 import * as S from './page.styled';
 import CommunityDescription from '../_components/CommunityDescription';
 
-const categoryOptions = [
-  { value: 1, label: '데일리 공유' },
-  { value: 2, label: '사색/고민' },
-  { value: 3, label: '칼럼' },
-];
-
 export default function CommunityWrite() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const type = searchParams.get('type') || 'post';
-  const isDaily = type === 'daily';
+  const logic = useCommunityWriteLogic();
 
-  const { createPost, isLoading } = useCreatePostMutation();
-  const { data: dailyData, isLoading: isDailyLoading } = useGetDailyQuestionsQuery();
-  const { open: openAlert } = useAlertModalStore();
-
-  const getInitialCategoryId = () => {
-    if (type === 'daily') return [1];
-    if (type === 'post') return [];
-    return [];
-  };
-
-  const methods = useForm({
-    mode: 'onSubmit',
-    defaultValues: {
-      categoryId: getInitialCategoryId(),
-      title: '',
-      content: '',
-      isAnonymous: isDaily,
-    },
-  });
-
-  const {
-    control,
-    handleSubmit,
-    setValue,
-    watch,
-    formState: { errors },
-  } = methods;
-
-  const watchedCategoryId = watch('categoryId');
-  const isDailyCategory = Array.isArray(watchedCategoryId) && watchedCategoryId.includes(1);
-
-  const updateUrlType = useCallback(
-    (type: 'post' | 'daily') => {
-      const newSearchParams = new URLSearchParams(searchParams);
-      newSearchParams.set('type', type);
-      router.replace(`${window.location.pathname}?${newSearchParams.toString()}`);
-    },
-    [searchParams, router],
-  );
-
-  const showDailyAlert = () => {
-    openAlert('alert', {
-      message: '오늘의 데일리에 답해주세요!',
-      type: 'confirm',
-      confirmText: '답변하러 가기',
-      cancelText: '마저 글쓰기',
-      onConfirm: () => {
-        router.push('/daily');
-      },
-      onCancel: () => {
-        setValue('categoryId', [2]);
-        updateUrlType('post');
-      },
-    });
-  };
-  const extractImageUrls = (htmlContent: string): string[] => {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(htmlContent, 'text/html');
-    const images = doc.querySelectorAll('img');
-    return Array.from(images).map((img) => img.src);
-  };
-
-  const onSubmit = (formData: { categoryId: number[]; title: string; content: string; isAnonymous: boolean }) => {
-    const categoryId = Array.isArray(formData.categoryId) ? formData.categoryId[0] : formData.categoryId;
-    const imageUrlList = extractImageUrls(formData.content);
-    const isAnonymousRendered = !!dailyData?.answer && isDaily && isDailyCategory;
-
-    const finalIsAnonymous = isAnonymousRendered ? formData.isAnonymous : false;
-
-    createPost({
-      title: formData.title,
-      categoryId: categoryId,
-      content: formData.content,
-      isAnonymous: finalIsAnonymous,
-      imageUrlList: imageUrlList,
-    });
-  };
-
-  useEffect(() => {
-    if (!isDaily || isDailyLoading || !dailyData) return;
-
-    if (!isDailyCategory) return;
-
-    if (!dailyData.answer) {
-      const timer = setTimeout(() => {
-        setValue('categoryId', [2]);
-        setValue('title', '');
-        updateUrlType('post');
-      }, 100);
-
-      return () => clearTimeout(timer);
-    }
-
-    if (dailyData.question && dailyData.answer) {
-      setValue('title', dailyData.question);
-    }
-  }, [isDaily, isDailyLoading, dailyData, isDailyCategory, setValue, updateUrlType]);
+  // 수정 모드에서 기존 데이터를 로딩 중일 때
+  if (logic.isEditMode && logic.isLoadingPost) {
+    return <Loading />;
+  }
 
   return (
     <S.Container>
@@ -141,123 +33,29 @@ export default function CommunityWrite() {
 
       <CommunityDescription />
 
-      <FormProvider {...methods}>
-        <S.WriteForm onSubmit={handleSubmit(onSubmit)}>
-          <S.CategoryBox>
-            <S.CategorySelect>
-              <Controller
-                name='categoryId'
-                control={control}
-                rules={{ required: '카테고리를 선택해 주세요.' }}
-                render={({ field }) => (
-                  <Select
-                    inputSize='md'
-                    label='카테고리'
-                    placeholder='카테고리 선택'
-                    options={categoryOptions}
-                    value={field.value || []}
-                    error={errors.categoryId?.message}
-                    onChange={(val) => {
-                      field.onChange(val);
-                      const categoryValue = Array.isArray(val) ? val[0] : val;
-
-                      if (categoryValue) {
-                        const newType = categoryValue === 1 ? 'daily' : 'post';
-                        updateUrlType(newType);
-
-                        if (categoryValue === 1) {
-                          setValue('isAnonymous', true);
-
-                          if (dailyData && !dailyData.answer) {
-                            showDailyAlert();
-                          }
-
-                          if (dailyData?.answer) {
-                            setValue('title', dailyData?.question ?? DEFAULT_DAILY_QUESTION);
-                          }
-                        }
-                      }
-                    }}
-                  />
-                )}
-              />
-            </S.CategorySelect>
-
-            {!!dailyData?.answer && isDaily && isDailyCategory && (
-              <S.AnonymousCheckbox>
-                <Controller
-                  name='isAnonymous'
-                  control={control}
-                  render={({ field }) => (
-                    <S.CheckboxWrapper>
-                      <Checkbox
-                        size='nm'
-                        isChecked={field.value}
-                        onToggle={(checked) => field.onChange(checked)}
-                        interactionVariant='normal'
-                        name='isAnonymous'
-                      />
-                      <S.CheckboxName>익명</S.CheckboxName>
-                    </S.CheckboxWrapper>
-                  )}
-                />
-              </S.AnonymousCheckbox>
-            )}
-          </S.CategoryBox>
-
-          <Controller
-            name='title'
-            control={control}
-            rules={{
-              required: '제목을 입력해 주세요.',
-              maxLength: {
-                value: 30,
-                message: '제목은 최대 30자까지 입력할 수 있어요.',
-              },
-              validate: (value) => {
-                // 허용 문자 정규식 (한글, 영문, 숫자, 특수문자, 이모지 포함)
-                const allowedRegex = /^[\p{L}\p{N}\p{P}\p{S}\p{Emoji}\s]+$/u;
-
-                return allowedRegex.test(value) || '제목에 사용할 수 없는 문자가 있어요';
-              },
-            }}
-            render={({ field }) => (
-              <Input
-                inputSize='lg'
-                label='제목'
-                placeholder='제목을 입력해 주세요.'
-                value={field.value || ''}
-                onChange={(val) => field.onChange(val)}
-                error={errors.title?.message}
-              />
-            )}
+      <FormProvider {...logic.methods}>
+        <S.WriteForm onSubmit={logic.methods.handleSubmit(logic.onSubmit)}>
+          <CategorySelector
+            options={logic.categoryProps.options}
+            error={logic.categoryProps.error}
+            onChange={logic.categoryProps.onChange}
+            onCategoryChange={logic.categoryProps.onCategoryChange}
+            showAnonymous={logic.showAnonymous}
+            onAnonymousToggle={(checked: boolean) => logic.methods.setValue('isAnonymous', checked)}
+            control={logic.methods.control}
           />
 
-          {dailyData?.answer && isDaily && (
-            <>
-              <Question
-                assignedQuestionId={dailyData?.assignedQuestionId ?? 0}
-                question={dailyData?.question ?? DEFAULT_DAILY_QUESTION}
-                answer={dailyData?.answer ?? ''}
-                hasAnswered={!!dailyData?.answer}
-                hideSubmitButton={true}
-                readOnlyMode={true}
-              />
-            </>
-          )}
+          <TitleInput
+            control={logic.methods.control}
+            error={logic.methods.formState.errors.title?.message}
+          />
 
-          <Controller
-            name='content'
-            control={control}
-            render={({ field }) => (
-              <S.ContentSection>
-                <Editor
-                  value={field.value || ''}
-                  onChange={(val) => field.onChange(val)}
-                  height={800}
-                />
-              </S.ContentSection>
-            )}
+          {logic.dailyProps && <DailyQuestionCard {...logic.dailyProps} />}
+
+          <PostEditor
+            {...logic.editorProps}
+            control={logic.methods.control}
+            onContentChange={(value: string) => logic.methods.setValue('content', value)}
           />
 
           <S.ButtonWrapper>
@@ -265,9 +63,9 @@ export default function CommunityWrite() {
               type='submit'
               color='primary'
               size='sm'
-              label='올리기'
+              label={logic.isEditMode ? '수정하기' : '올리기'}
               interactionVariant='normal'
-              isDisabled={isLoading}
+              isDisabled={logic.isLoading}
             />
           </S.ButtonWrapper>
         </S.WriteForm>

--- a/src/components/organisms/Editor/CustomImage.tsx
+++ b/src/components/organisms/Editor/CustomImage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Node, mergeAttributes } from '@tiptap/core';
-import { ReactNodeViewRenderer, NodeViewWrapper } from '@tiptap/react';
+import { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { ReactNodeViewRenderer, NodeViewWrapper, Editor } from '@tiptap/react';
 
 import ResizableImage from './ResizableImage';
 
@@ -19,18 +20,29 @@ export interface CustomImageOptions {
   HTMLAttributes: Record<string, unknown>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CustomImageComponent = ({ node, updateAttributes, editor, getPos }: any) => {
+interface CustomImageComponentProps {
+  node: ProseMirrorNode;
+  updateAttributes: (attributes: Record<string, unknown>) => void;
+  editor: Editor;
+  getPos: () => number | undefined;
+}
+
+const CustomImageComponent = ({ node, updateAttributes, editor, getPos }: CustomImageComponentProps) => {
   const handleResize = (width: number, height: number) => {
     updateAttributes({ width, height });
   };
 
-  // Get current text alignment
   const getCurrentTextAlign = () => {
-    const { from } = editor.state.selection;
-    const resolvedPos = editor.state.doc.resolve(getPos());
-    const attrs = resolvedPos.parent?.attrs;
-    return attrs?.textAlign || 'left';
+    const pos = getPos();
+    if (pos === undefined) return 'left';
+
+    try {
+      const resolvedPos = editor.state.doc.resolve(pos);
+      const attrs = resolvedPos.parent?.attrs;
+      return attrs?.textAlign || 'left';
+    } catch {
+      return 'left';
+    }
   };
 
   return (

--- a/src/components/organisms/Editor/Editor.tsx
+++ b/src/components/organisms/Editor/Editor.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import BulletList from '@tiptap/extension-bullet-list';
 import CharacterCount from '@tiptap/extension-character-count';
 import Color from '@tiptap/extension-color';
 import FontFamily from '@tiptap/extension-font-family';
 import { Link } from '@tiptap/extension-link';
-import ListItem from '@tiptap/extension-list-item';
-import OrderedList from '@tiptap/extension-ordered-list';
 import Placeholder from '@tiptap/extension-placeholder';
 import { TextAlign } from '@tiptap/extension-text-align';
 import { TextStyle } from '@tiptap/extension-text-style';
 import { Underline } from '@tiptap/extension-underline';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { StarterKit } from '@tiptap/starter-kit';
+import { useEffect } from 'react';
 
 import { CustomImage } from './CustomImage';
 import CustomToolbar from './CustomToolbar/CustomToolbar';
@@ -90,6 +88,12 @@ export default function Editor({
       onChange(addListStyles(html));
     },
   });
+
+  useEffect(() => {
+    if (editor && value !== editor.getHTML()) {
+      editor.commands.setContent(value);
+    }
+  }, [editor, value]);
 
   if (!editor) {
     return null;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -85,6 +85,7 @@ export const END_POINTS_V1 = {
   POSTS: {
     LIST: `${BASE_PATH_V1.POSTS}`,
     POST_CREATE: `${BASE_PATH_V1.POSTS}`,
+    POST_UPDATE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}`,
     POST_DETAIL: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}`,
     POST_LIKE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}/likes`,
     POST_SAVE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}/saves`,

--- a/src/hooks/api/post/useGetPost.ts
+++ b/src/hooks/api/post/useGetPost.ts
@@ -3,10 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { postApi } from '@/api/postApis';
 import { POST_QUERY_KEYS } from '@/constants/queryKeys';
 
-export const useGetPost = (postId: string) => {
+export const useGetPost = (postId: string, options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: [...POST_QUERY_KEYS.POST, postId],
     queryFn: () => postApi.getPost(postId),
-    enabled: !!postId,
+    enabled: !!postId && (options?.enabled ?? true),
   });
 };

--- a/src/hooks/api/post/useUpdatePost.ts
+++ b/src/hooks/api/post/useUpdatePost.ts
@@ -22,6 +22,7 @@ export const useUpdatePostMutation = () => {
       title: string;
       categoryId: number;
       content: string;
+      isAnonymous: boolean;
       imageUrlList: string[];
       deleteUrlList: string[];
     }) => postApi.updatePost(postId, updateData),
@@ -29,7 +30,10 @@ export const useUpdatePostMutation = () => {
       queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST] });
       queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST, postId] });
 
-      router.push(`/community/post/${postId}`);
+      openAlert('alert', {
+        message: '수정되었어요!',
+        onConfirm: () => router.push(`/community/post/${postId}`),
+      });
     },
     onError: (error: HTTPError) => {
       switch (error.code) {

--- a/src/hooks/api/post/useUpdatePost.ts
+++ b/src/hooks/api/post/useUpdatePost.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { HTTPError } from '@/api/axios/errors/HTTPError';
+import { postApi } from '@/api/postApis';
+import { POST_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAlertModalStore } from '@/stores/useModalStore';
+
+export const useUpdatePostMutation = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { open: openAlert } = useAlertModalStore();
+
+  const mutation = useMutation({
+    mutationFn: ({
+      postId,
+      ...updateData
+    }: {
+      postId: string;
+      title: string;
+      categoryId: number;
+      content: string;
+      imageUrlList: string[];
+      deleteUrlList: string[];
+    }) => postApi.updatePost(postId, updateData),
+    onSuccess: (_result, { postId }) => {
+      queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST] });
+      queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST, postId] });
+
+      router.push(`/community/post/${postId}`);
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '사용자를 찾을 수 없습니다.' });
+          break;
+        case 'FORBIDDEN_ERROR':
+          openAlert('alert', { message: '사용자 권한이 없습니다.' });
+          break;
+        case 'CATEGORY_NOT_ALLOWED_ANONYMOUS_POST_ERROR':
+          openAlert('alert', { message: '익명 게시글을 등록할 수 없는 카테고리입니다.' });
+          break;
+        case 'POST_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '게시물을 찾을 수 없습니다.' });
+          break;
+        case 'POST_FORBIDDEN_ERROR':
+          openAlert('alert', { message: '본인이 작성한 게시글만 수정/삭제가 가능합니다.' });
+          break;
+        case 'TITLE_NOTBLANK_ERROR':
+          openAlert('alert', { message: '게시글 제목을 1자 이상 작성해주세요.' });
+          break;
+        case 'TITLE_SIZE_ERROR':
+          openAlert('alert', { message: '게시글 제목은 30자 이하여야 합니다.' });
+          break;
+        case 'CATEGORY_WRITE_FORBIDDEN_ERROR':
+          openAlert('alert', { message: '선택한 카테고리의 게시글을 작성할 수 있는 권한이 없습니다.' });
+          break;
+        case 'POST_ALREADY_DELETED_ERROR':
+          openAlert('alert', { message: '이미 삭제된 게시글입니다.' });
+          break;
+        case 'ISANONYMOUS_NOTNULL_ERROR':
+          openAlert('alert', { message: '게시글 익명 여부는 필수입니다.' });
+          break;
+        case 'POST_HIDDEN_ERROR':
+          openAlert('alert', { message: '숨김 처리된 게시글입니다.' });
+          break;
+        default:
+          openAlert('error', { message: error.message || '게시글 수정에 실패했습니다.' });
+          break;
+      }
+    },
+  });
+
+  return { updatePost: mutation.mutate, isLoading: mutation.isPending };
+};

--- a/src/hooks/useCommunityWriteLogic.ts
+++ b/src/hooks/useCommunityWriteLogic.ts
@@ -1,0 +1,244 @@
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { DEFAULT_DAILY_QUESTION } from '@/constants/common';
+import useGetDailyQuestionsQuery from '@/hooks/api/daily/useGetDailyQuestions';
+import { useCreatePostMutation } from '@/hooks/api/post/useCreatePost';
+import { useGetPost } from '@/hooks/api/post/useGetPost';
+import { useUpdatePostMutation } from '@/hooks/api/post/useUpdatePost';
+import { useAlertModalStore } from '@/stores/useModalStore';
+import { CommunityWriteFormData, CategoryOption, UseCommunityWriteLogicReturn } from '@/types/communityWrite';
+import { extractImageUrls, calculateDeleteUrls, getCategoryType, extractCategoryId } from '@/utils/postUtils';
+
+const categoryOptions: CategoryOption[] = [
+  { value: 1, label: '데일리 공유' },
+  { value: 2, label: '사색/고민' },
+  { value: 3, label: '칼럼' },
+];
+
+export const useCommunityWriteLogic = (): UseCommunityWriteLogicReturn => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const type = searchParams.get('type') || 'post';
+  const editPostId = searchParams.get('edit');
+  const isEditMode = !!editPostId;
+  const isDaily = type === 'daily';
+
+  // 수정 모드에서 useEffect 초기화를 한번만 실행하기 위한 ref 입니다!
+  const isInitialized = useRef(false);
+
+  const { createPost, isLoading: isCreating } = useCreatePostMutation();
+  const { updatePost, isLoading: isUpdating } = useUpdatePostMutation();
+  const { data: existingPost, isLoading: isLoadingPost } = useGetPost(editPostId || '', { enabled: isEditMode });
+  const { data: dailyData, isLoading: isDailyLoading } = useGetDailyQuestionsQuery();
+  const { open: openAlert } = useAlertModalStore();
+
+  const isLoading = isCreating || isUpdating;
+
+  const getInitialCategoryId = () => {
+    if (isEditMode && existingPost) {
+      return [existingPost.category.categoryId];
+    }
+    if (type === 'daily') return [1];
+    if (type === 'post') return [];
+    return [];
+  };
+
+  const getInitialValues = () => {
+    if (isEditMode && existingPost) {
+      return {
+        categoryId: [existingPost.category.categoryId],
+        title: existingPost.title,
+        content: existingPost.content,
+        isAnonymous: existingPost.author?.isAnonymous ?? false,
+      };
+    }
+    return {
+      categoryId: getInitialCategoryId(),
+      title: '',
+      content: '',
+      isAnonymous: isDaily,
+    };
+  };
+
+  const methods = useForm({
+    mode: 'onSubmit',
+    defaultValues: getInitialValues(),
+  });
+
+  const {
+    setValue,
+    watch,
+    reset,
+    formState: { errors },
+  } = methods;
+
+  const watchedCategoryId = watch('categoryId');
+  const isDailyCategory = Array.isArray(watchedCategoryId) && watchedCategoryId.includes(1);
+
+  const updateUrlType = useCallback(
+    (type: 'post' | 'daily') => {
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.set('type', type);
+      router.replace(`${window.location.pathname}?${newSearchParams.toString()}`);
+    },
+    [searchParams, router],
+  );
+
+  const showDailyAlert = () => {
+    openAlert('alert', {
+      message: '오늘의 데일리에 답해주세요!',
+      type: 'confirm',
+      confirmText: '답변하러 가기',
+      cancelText: '마저 글쓰기',
+      onConfirm: () => {
+        router.push('/daily');
+      },
+      onCancel: () => {
+        setValue('categoryId', [2]);
+        updateUrlType('post');
+      },
+    });
+  };
+
+  const onSubmit = (formData: CommunityWriteFormData) => {
+    const categoryId = extractCategoryId(formData.categoryId);
+    const imageUrlList = extractImageUrls(formData.content);
+    const isAnonymousRendered =
+      (isEditMode && existingPost?.daily && isDailyCategory) || (!!dailyData?.answer && isDaily && isDailyCategory);
+
+    const finalIsAnonymous = isAnonymousRendered ? formData.isAnonymous : false;
+
+    if (isEditMode && editPostId) {
+      const existingImageUrls = extractImageUrls(existingPost?.content || '');
+      const deleteUrlList = calculateDeleteUrls(existingImageUrls, imageUrlList);
+
+      updatePost({
+        postId: editPostId,
+        title: formData.title,
+        categoryId: categoryId,
+        content: formData.content,
+        imageUrlList: imageUrlList,
+        deleteUrlList: deleteUrlList,
+      });
+    } else {
+      createPost({
+        title: formData.title,
+        categoryId: categoryId,
+        content: formData.content,
+        isAnonymous: finalIsAnonymous,
+        imageUrlList: imageUrlList,
+      });
+    }
+  };
+
+  const handleCategoryChange = (categoryValue: number) => {
+    const newType = getCategoryType(categoryValue);
+    updateUrlType(newType);
+
+    if (categoryValue === 1) {
+      setValue('isAnonymous', true);
+
+      if (isEditMode && existingPost?.daily) {
+        setValue('title', existingPost.daily.question);
+      } else {
+        if (dailyData && !dailyData.answer) {
+          showDailyAlert();
+        }
+
+        if (dailyData?.answer) {
+          setValue('title', dailyData?.question ?? DEFAULT_DAILY_QUESTION);
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (isEditMode && existingPost && !isLoadingPost && !isInitialized.current) {
+      reset({
+        categoryId: [existingPost.category.categoryId],
+        title: existingPost.title,
+        content: existingPost.content,
+        isAnonymous: existingPost.author?.isAnonymous ?? false,
+      });
+
+      const categoryId = existingPost.category.categoryId;
+      updateUrlType(getCategoryType(categoryId));
+
+      isInitialized.current = true;
+    }
+  }, [isEditMode, existingPost, isLoadingPost, reset, updateUrlType]);
+
+  useEffect(() => {
+    if (!isDaily || isDailyLoading || !dailyData || isEditMode) return;
+
+    if (!isDailyCategory) return;
+
+    if (!dailyData.answer) {
+      const timer = setTimeout(() => {
+        setValue('categoryId', [2]);
+        setValue('title', '');
+        updateUrlType('post');
+      }, 100);
+
+      return () => clearTimeout(timer);
+    }
+
+    if (dailyData.question && dailyData.answer) {
+      setValue('title', dailyData.question);
+    }
+  }, [isDaily, isDailyLoading, dailyData, isDailyCategory, setValue, updateUrlType, isEditMode]);
+
+  const showAnonymous =
+    (isEditMode && existingPost?.daily && isDailyCategory) || (!!dailyData?.answer && isDaily && isDailyCategory);
+
+  const dailyQuestionProps = (() => {
+    if (isEditMode && existingPost?.daily && isDailyCategory) {
+      return {
+        question: existingPost.daily.question,
+        answer: existingPost.daily.answer,
+        assignedQuestionId: 0,
+      };
+    }
+
+    if (dailyData?.answer && isDaily) {
+      return {
+        question: dailyData?.question ?? DEFAULT_DAILY_QUESTION,
+        answer: dailyData?.answer ?? '',
+        assignedQuestionId: dailyData?.assignedQuestionId ?? 0,
+      };
+    }
+
+    return null;
+  })();
+
+  return {
+    // Form 관련
+    methods,
+    onSubmit,
+    isLoading,
+
+    // Category 관련
+    categoryProps: {
+      options: categoryOptions,
+      value: watchedCategoryId || [],
+      error: errors.categoryId?.message,
+      onChange: (value: number[]) => setValue('categoryId', value),
+      onCategoryChange: handleCategoryChange,
+    },
+
+    // Daily 관련
+    dailyProps: dailyQuestionProps,
+
+    // Editor 관련
+    editorProps: {
+      height: 800,
+    },
+
+    // 상태
+    isEditMode,
+    isLoadingPost,
+    showAnonymous,
+  };
+};

--- a/src/hooks/useCommunityWriteLogic.ts
+++ b/src/hooks/useCommunityWriteLogic.ts
@@ -119,6 +119,7 @@ export const useCommunityWriteLogic = (): UseCommunityWriteLogicReturn => {
         title: formData.title,
         categoryId: categoryId,
         content: formData.content,
+        isAnonymous: finalIsAnonymous,
         imageUrlList: imageUrlList,
         deleteUrlList: deleteUrlList,
       });
@@ -193,6 +194,10 @@ export const useCommunityWriteLogic = (): UseCommunityWriteLogicReturn => {
   const showAnonymous =
     (isEditMode && existingPost?.daily && isDailyCategory) || (!!dailyData?.answer && isDaily && isDailyCategory);
 
+  // 데일리 공유 익명 글 수정 시 익명 체크박스 비활성화
+  const isAnonymousDisabled =
+    isEditMode && existingPost?.category.categoryId === 1 && existingPost?.author?.isAnonymous === true;
+
   const dailyQuestionProps = (() => {
     if (isEditMode && existingPost?.daily && isDailyCategory) {
       return {
@@ -240,5 +245,6 @@ export const useCommunityWriteLogic = (): UseCommunityWriteLogicReturn => {
     isEditMode,
     isLoadingPost,
     showAnonymous,
+    isAnonymousDisabled,
   };
 };

--- a/src/types/communityWrite.ts
+++ b/src/types/communityWrite.ts
@@ -51,4 +51,5 @@ export interface UseCommunityWriteLogicReturn {
   isEditMode: boolean;
   isLoadingPost: boolean;
   showAnonymous: boolean;
+  isAnonymousDisabled: boolean;
 }

--- a/src/types/communityWrite.ts
+++ b/src/types/communityWrite.ts
@@ -1,0 +1,54 @@
+import { Control, UseFormReturn } from 'react-hook-form';
+
+export interface CommunityWriteFormData {
+  categoryId: number[];
+  title: string;
+  content: string;
+  isAnonymous: boolean;
+}
+
+export interface CategoryOption {
+  value: number;
+  label: string;
+}
+
+export interface CategorySelectorProps {
+  options: CategoryOption[];
+  value: number[];
+  error?: string;
+  onChange: (value: number[]) => void;
+  onCategoryChange: (categoryId: number) => void;
+}
+
+export type FormControl = Control<CommunityWriteFormData>;
+
+export interface DailyQuestionCardProps {
+  question: string;
+  answer: string;
+  assignedQuestionId?: number;
+}
+
+export interface PostEditorProps {
+  height?: number;
+}
+
+export interface UseCommunityWriteLogicReturn {
+  // Form 관련
+  methods: UseFormReturn<CommunityWriteFormData>;
+  onSubmit: (data: CommunityWriteFormData) => void;
+  isLoading: boolean;
+
+  // Category 관련
+  categoryProps: CategorySelectorProps;
+
+  // Daily 관련
+  dailyProps: DailyQuestionCardProps | null;
+
+  // Editor 관련
+  editorProps: PostEditorProps;
+
+  // 상태
+  isEditMode: boolean;
+  isLoadingPost: boolean;
+  showAnonymous: boolean;
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -53,6 +53,18 @@ export interface CreatePostResponse extends ApiResponse {
   result: Post;
 }
 
+export type UpdatePostRequest = {
+  title: string;
+  categoryId: number;
+  content: string;
+  imageUrlList: string[];
+  deleteUrlList: string[];
+};
+
+export interface UpdatePostResponse {
+  result: Post;
+}
+
 export interface PostResponse extends ApiResponse {
   result: {
     postId: number;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -57,6 +57,7 @@ export type UpdatePostRequest = {
   title: string;
   categoryId: number;
   content: string;
+  isAnonymous: boolean;
   imageUrlList: string[];
   deleteUrlList: string[];
 };

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -1,0 +1,30 @@
+/**
+ * HTML 콘텐츠에서 이미지 URL을 추출합니다.
+ */
+export const extractImageUrls = (htmlContent: string): string[] => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlContent, 'text/html');
+  const images = doc.querySelectorAll('img');
+  return Array.from(images).map((img) => img.src);
+};
+
+/**
+ * 기존 이미지와 새 이미지를 비교하여 삭제할 이미지 URL 목록을 생성합니다.
+ */
+export const calculateDeleteUrls = (existingImageUrls: string[], newImageUrls: string[]): string[] => {
+  return existingImageUrls.filter((url) => !newImageUrls.includes(url));
+};
+
+/**
+ * 카테고리 ID를 기반으로 타입을 결정합니다.
+ */
+export const getCategoryType = (categoryId: number): 'daily' | 'post' => {
+  return categoryId === 1 ? 'daily' : 'post';
+};
+
+/**
+ * 배열 형태의 카테고리 ID에서 첫 번째 값을 추출합니다.
+ */
+export const extractCategoryId = (categoryId: number | number[]): number => {
+  return Array.isArray(categoryId) ? categoryId[0] : categoryId;
+};


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #https://github.com/Oncognier/cogroom-fe/issues/446

## 📋 작업 내용

- 기존 게시글 업로드 페이지를 활용한 수정 페이지 구현
    - `/community/write?edit=64&type=daily`
    - 게시글 수정 시 전송해야하는 deleteUrlList[] 의 경우 기존 이미지와 새 이미지를 비교하여 삭제할 이미지 URL 목록을 생성하여 전송
    - 사용자가 데일리 공유했던 게시글을 수정할 경우 다른 카테고리로 이동 가능
    

## 🛠️ 특이 사항

- 게시글 수정 API 엔드포인트 변경 예정입니다!!!!!!!!!!!!! 
담당자 현진님, 기간 미정.
등록/수정 차이에 따른 UI 및 API 로 응답값 보내는것 까지는 완성되어있습니다.


- `Editor.tsx` 내에 useEffect 로직 설명
```
 useEffect(() => {
    if (editor && value !== editor.getHTML()) {
      editor.commands.setContent(value);
    }
  }, [editor, value]);
  
    if (!editor) {
    return null;
  }

  return (
    <S.EditorWrapper className={className}>
      <CustomToolbar editor={editor} />
      <S.EditorContent height={height}>
        <EditorContent editor={editor} />
      </S.EditorContent>
    </S.EditorWrapper>
  );
```
이유 : TipTap의 useEditor는 content를 초기화 시 한 번만 반영합니다. 
수정 모드에서 기존 데이터를 받아와도 value 변경이 에디터에 자동 적용되지 않아 렌더링이 안 됩니다. 
(field.value 로 값을 받아오지만 실제 데이터는 화면에 보이지 않는 상황.)
그래서 useEffect로 value 변경 시 editor.commands.setContent(value)를 호출하였습니다.

## ⚡️ 리뷰 요구사항 (선택)
