### PR TITLE
[FEAT] 커뮤니티 > 게시글 조회 페이지 > 게시글 댓글 영역 추가 #463

### DIFF
--- a/src/api/commentApis.ts
+++ b/src/api/commentApis.ts
@@ -2,8 +2,55 @@ import { AxiosResponse } from 'axios';
 
 import { END_POINTS_V1 } from '@/constants/api';
 import { ApiResponse } from '@/types/api';
+import {
+  CreateCommentRequest,
+  CreateCommentResponse,
+  CommentListRequest,
+  CommentListResponse,
+  UpdateCommentRequest,
+  UpdateCommentResponse,
+  DeleteCommentLikeResponse,
+} from '@/types/comment';
 
 import { axiosInstance } from './axios/axiosInstance';
+
+const createComment = async (
+  postId: string,
+  { parentId, content, isAnonymous, mentionedList }: CreateCommentRequest,
+) => {
+  const { data } = await axiosInstance.post<CreateCommentRequest, AxiosResponse<CreateCommentResponse>>(
+    END_POINTS_V1.COMMENTS.CREATE(postId),
+    {
+      parentId,
+      content,
+      isAnonymous,
+      mentionedList,
+    },
+  );
+
+  return data.result;
+};
+
+const getCommentList = async (postId: string, params: CommentListRequest) => {
+  const { data } = await axiosInstance.get<CommentListResponse>(END_POINTS_V1.COMMENTS.LIST(postId), {
+    params,
+  });
+
+  return data.result;
+};
+
+const updateComment = async (commentId: string, { content, isAnonymous, mentionedList }: UpdateCommentRequest) => {
+  const { data } = await axiosInstance.patch<UpdateCommentRequest, AxiosResponse<UpdateCommentResponse>>(
+    END_POINTS_V1.COMMENTS.UPDATE(commentId),
+    {
+      content,
+      isAnonymous,
+      mentionedList,
+    },
+  );
+
+  return data.result;
+};
 
 const deleteComment = async ({ commentId }: { commentId: string }) => {
   const { data } = await axiosInstance.delete<null, AxiosResponse<ApiResponse>>(
@@ -13,6 +60,25 @@ const deleteComment = async ({ commentId }: { commentId: string }) => {
   return data;
 };
 
+const toggleCommentLike = async (commentId: string) => {
+  const { data } = await axiosInstance.post(END_POINTS_V1.COMMENTS.LIKE(commentId));
+
+  return data.result;
+};
+
+const deleteCommentLike = async (commentId: string) => {
+  const { data } = await axiosInstance.delete<null, AxiosResponse<DeleteCommentLikeResponse>>(
+    END_POINTS_V1.COMMENTS.DELETE_LIKE(commentId),
+  );
+
+  return data.result;
+};
+
 export const commentApi = {
+  createComment,
+  getCommentList,
+  updateComment,
   deleteComment,
+  toggleCommentLike,
+  deleteCommentLike,
 };

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.styled.ts
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.styled.ts
@@ -5,21 +5,16 @@ import styled from '@emotion/styled';
 export const PostCommentsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 2.4rem;
 `;
 
 export const CommentsHeader = styled.div`
   ${({ theme }) => theme.typography.label1.semibold};
   color: ${({ theme }) => theme.semantic.label.normal};
-  padding: 1rem 0;
 `;
 
-export const EmptyComments = styled.div`
+export const CommentsTopWrapper = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 3rem;
-  text-align: center;
-  color: ${({ theme }) => theme.semantic.label.assistive};
-  ${({ theme }) => theme.typography.body2.regular};
+  flex-direction: column;
+  gap: 1.6rem;
 `;

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
@@ -1,15 +1,65 @@
+import { useMemo } from 'react';
+
+import InfiniteScrollSentinel from '@/components/atoms/InfiniteScrollSentinel/InfiniteScrollSentinel';
+import CommentField from '@/components/molecules/CommentField/CommentField';
+import CommentList from '@/components/molecules/CommentList/CommentList';
+import { useGetComments } from '@/hooks/api/comment/useGetComments';
+import useGetUserSummaryQuery from '@/hooks/api/member/useGetUserSummary';
+import useScroll from '@/hooks/useScroll';
+
 import * as S from './PostComments.styled';
 
 interface PostCommentsProps {
+  postId: string;
   commentCount: number;
 }
 
-export default function PostComments({ commentCount }: PostCommentsProps) {
+export default function PostComments({ postId, commentCount }: PostCommentsProps) {
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage, refetch } = useGetComments(postId);
+  const { data: userSummary } = useGetUserSummaryQuery();
+
+  const comments = useMemo(() => {
+    const result =
+      data?.pages.flatMap((page) => {
+        return page.data;
+      }) ?? [];
+
+    // createdAt 기준 내림차순 처리함.
+    return result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [data]);
+
+  const { observerRef } = useScroll({
+    nextPage: !!hasNextPage,
+    fetchNext: fetchNextPage,
+  });
+
+  const handleCommentUpdated = () => {
+    refetch();
+  };
+
   return (
     <S.PostCommentsWrapper>
-      <S.CommentsHeader>댓글 {commentCount}개</S.CommentsHeader>
+      <S.CommentsTopWrapper>
+        <S.CommentsHeader>댓글 {commentCount}개</S.CommentsHeader>
+        <CommentField
+          postId={postId}
+          onSuccess={handleCommentUpdated}
+        />
+      </S.CommentsTopWrapper>
 
-      <S.EmptyComments>댓글 기능 개발 예정</S.EmptyComments>
+      <CommentList
+        comments={comments}
+        postId={postId}
+        isLoading={isLoading && comments.length === 0}
+        isAdmin={userSummary?.memberRole === 'ADMIN'}
+        onCommentUpdated={handleCommentUpdated}
+      />
+
+      <InfiniteScrollSentinel
+        observerRef={observerRef}
+        hasNextPage={!!hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+      />
     </S.PostCommentsWrapper>
   );
 }

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
@@ -12,9 +12,10 @@ import * as S from './PostComments.styled';
 interface PostCommentsProps {
   postId: string;
   commentCount: number;
+  isPostAnonymous: boolean;
 }
 
-export default function PostComments({ postId, commentCount }: PostCommentsProps) {
+export default function PostComments({ postId, commentCount, isPostAnonymous }: PostCommentsProps) {
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage, refetch } = useGetComments(postId);
   const { data: userSummary } = useGetUserSummaryQuery();
 
@@ -44,6 +45,7 @@ export default function PostComments({ postId, commentCount }: PostCommentsProps
         <CommentField
           postId={postId}
           onSuccess={handleCommentUpdated}
+          showAnonymousCheckbox={isPostAnonymous}
         />
       </S.CommentsTopWrapper>
 
@@ -52,6 +54,7 @@ export default function PostComments({ postId, commentCount }: PostCommentsProps
         postId={postId}
         isLoading={isLoading && comments.length === 0}
         isAdmin={userSummary?.memberRole === 'ADMIN'}
+        isPostAnonymous={isPostAnonymous}
         onCommentUpdated={handleCommentUpdated}
       />
 

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostComments/PostComments.tsx
@@ -25,8 +25,7 @@ export default function PostComments({ postId, commentCount, isPostAnonymous }: 
         return page.data;
       }) ?? [];
 
-    // createdAt 기준 내림차순 처리함.
-    return result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return result;
   }, [data]);
 
   const { observerRef } = useScroll({

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostLikesSaved/PostLikesSaved.styled.ts
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostLikesSaved/PostLikesSaved.styled.ts
@@ -7,6 +7,8 @@ export const PostLikeSavedWrapper = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 1.2rem;
+  padding-bottom: 1.6rem;
+  border-bottom: 1px solid ${({ theme }) => theme.semantic.line.normal};
 `;
 
 export const IconMargin = styled.svg`

--- a/src/app/(shared)/(standard)/community/post/[id]/page.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/page.tsx
@@ -95,6 +95,7 @@ export default function PostPage() {
         <PostComments
           postId={postId}
           commentCount={post.commentCount}
+          isPostAnonymous={post.isAnonymous}
         />
       </S.PostSectionsWrapper>
     </S.PostPageContainer>

--- a/src/app/(shared)/(standard)/community/post/[id]/page.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/page.tsx
@@ -92,7 +92,10 @@ export default function PostPage() {
           saveCount={post.saveCount}
           isSaved={post.myStatus.isSaved}
         />
-        <PostComments commentCount={post.commentCount} />
+        <PostComments
+          postId={postId}
+          commentCount={post.commentCount}
+        />
       </S.PostSectionsWrapper>
     </S.PostPageContainer>
   );

--- a/src/components/molecules/CommentField/CommentField.styled.ts
+++ b/src/components/molecules/CommentField/CommentField.styled.ts
@@ -7,11 +7,15 @@ export const Wrapper = styled.div`
   height: 18rem;
   border-radius: 1.2rem;
   background-color: ${({ theme }) => theme.semantic.static.white};
-  border: 1px solid ${({ theme }) => theme.semantic.background.elevated.alternative};
+  border: 1px solid ${({ theme }) => theme.palette.blue[80]};
   padding: 1.2rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+
+  &:focus-within {
+    border: 1px solid ${({ theme }) => theme.semantic.background.elevated.alternative};
+  }
 `;
 
 export const TextareaContainer = styled.div`

--- a/src/components/molecules/CommentField/CommentField.styled.ts
+++ b/src/components/molecules/CommentField/CommentField.styled.ts
@@ -59,8 +59,20 @@ export const CharTotalCounter = styled.span`
   color: ${({ theme }) => theme.semantic.label.assistive};
 `;
 
+export const CheckboxWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+`;
+
+export const CheckboxLabel = styled.span`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;
+
 export const ButtonWrapper = styled.div`
   display: flex;
-  gap: 0.8rem;
+  gap: 1.5rem;
   align-items: center;
 `;

--- a/src/components/molecules/CommentField/CommentField.styled.ts
+++ b/src/components/molecules/CommentField/CommentField.styled.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 18rem;
+  border-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.semantic.static.white};
+  border: 1px solid ${({ theme }) => theme.semantic.background.elevated.alternative};
+  padding: 1.2rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+export const TextareaContainer = styled.div`
+  width: 100%;
+  height: 100px;
+  position: relative;
+`;
+
+export const Textarea = styled.textarea`
+  width: 100%;
+  height: 100%;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow-y: auto;
+  background: transparent;
+  color: ${({ theme }) => theme.semantic.label.neutral};
+  ${({ theme }) => theme.typography.body1.regular};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.semantic.label.assistive};
+  }
+`;
+
+export const BottomSection = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+`;
+
+export const CounterWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.4rem;
+`;
+
+export const CharCurrentCounter = styled.span`
+  ${({ theme }) => theme.typography.label2.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;
+
+export const CharTotalCounter = styled.span`
+  ${({ theme }) => theme.typography.label2.regular};
+  color: ${({ theme }) => theme.semantic.label.assistive};
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+`;

--- a/src/components/molecules/CommentField/CommentField.tsx
+++ b/src/components/molecules/CommentField/CommentField.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, ChangeEvent } from 'react';
 
+import Checkbox from '@/components/atoms/Checkbox/Checkbox';
 import SolidButton from '@/components/atoms/SolidButton/SolidButton';
 import { useCreateComment } from '@/hooks/api/comment/useCreateComment';
 import { useUpdateComment } from '@/hooks/api/comment/useUpdateComment';
@@ -17,6 +18,7 @@ interface CommentFieldProps {
   mentionedList?: number[];
   disabled?: boolean;
   onSuccess?: () => void;
+  showAnonymousCheckbox?: boolean;
   // 수정 모드용 props
   isEdit?: boolean;
   commentId?: string;
@@ -28,17 +30,19 @@ export default function CommentField({
   postId,
   placeholder = '댓글을 입력해주세요',
   maxLength = 1000,
-  isAnonymous = false,
+  isAnonymous,
   parentId,
   mentionedList = [],
   disabled = false,
   onSuccess,
+  showAnonymousCheckbox = false,
   isEdit = false,
   commentId,
   initialContent = '',
   onCancel,
 }: CommentFieldProps) {
   const [content, setContent] = useState(initialContent);
+  const [localIsAnonymous, setLocalIsAnonymous] = useState(false);
   const { createComment, isLoading: createLoading } = useCreateComment(postId);
   const updateCommentMutation = useUpdateComment();
 
@@ -60,7 +64,7 @@ export default function CommentField({
             commentId,
             data: {
               content: content.trim(),
-              isAnonymous,
+              isAnonymous: localIsAnonymous,
               mentionedList,
             },
           },
@@ -75,7 +79,7 @@ export default function CommentField({
         createComment(
           {
             content: content.trim(),
-            isAnonymous,
+            isAnonymous: localIsAnonymous,
             parentId,
             mentionedList,
           },
@@ -94,7 +98,7 @@ export default function CommentField({
     commentId,
     updateCommentMutation,
     createComment,
-    isAnonymous,
+    localIsAnonymous,
     parentId,
     mentionedList,
     onSuccess,
@@ -129,6 +133,18 @@ export default function CommentField({
               interactionVariant='normal'
               onClick={onCancel}
             />
+          )}
+          {showAnonymousCheckbox && (
+            <S.CheckboxWrapper>
+              <Checkbox
+                size='nm'
+                isChecked={localIsAnonymous}
+                onToggle={setLocalIsAnonymous}
+                interactionVariant='normal'
+                name='commentAnonymous'
+              />
+              <S.CheckboxLabel>익명</S.CheckboxLabel>
+            </S.CheckboxWrapper>
           )}
           <SolidButton
             label={isEdit ? '수정하기' : '입력'}

--- a/src/components/molecules/CommentItem/CommentItem.styled.ts
+++ b/src/components/molecules/CommentItem/CommentItem.styled.ts
@@ -60,9 +60,10 @@ export const AuthorDetails = styled.div`
   gap: 0.2rem;
 `;
 
-export const AuthorName = styled.span<{ $isActive: boolean }>`
+export const AuthorName = styled.span<{ $isActive: boolean; $isClickable?: boolean }>`
   ${({ theme }) => theme.typography.label2.semibold};
   color: ${({ theme, $isActive }) => ($isActive ? theme.semantic.label.normal : theme.semantic.label.alternative)};
+  cursor: ${({ $isClickable }) => ($isClickable ? 'pointer' : 'default')};
 `;
 
 export const CommentTime = styled.span`

--- a/src/components/molecules/CommentItem/CommentItem.styled.ts
+++ b/src/components/molecules/CommentItem/CommentItem.styled.ts
@@ -1,0 +1,180 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const CommentItemWrapper = styled.div<{ $isChild?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 0.8rem;
+
+  padding-bottom: 1.6rem;
+  border-bottom: ${({ $isChild, theme }) => ($isChild ? 'none' : `1px solid ${theme.semantic.line.normal}`)};
+`;
+
+export const CommentCotent = styled.div<{ $isChild: boolean; $isActive: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  justify-content: ${({ $isActive }) => ($isActive ? 'flex-start' : 'center')};
+  align-items: ${({ $isActive }) => ($isActive ? 'flex-start' : 'center')};
+
+  width: ${({ $isChild, $isActive }) => (!$isActive ? '100%' : $isChild ? '69.7rem' : '74.6rem')};
+  height: 100%;
+  padding: 2rem 1.4rem;
+
+  ${({ theme }) => theme.typography.body1.regular};
+  background-color: ${({ theme, $isActive }) => ($isActive ? theme.palette.blue[99] : theme.palette.coolNeutral[99])};
+  color: ${({ theme, $isActive }) => ($isActive ? theme.semantic.label.normal : theme.palette.coolNeutral[70])};
+
+  border-radius: 2rem;
+`;
+
+export const CommentHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  height: 4.8rem;
+`;
+
+export const AuthorInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+`;
+
+export const AvatarWrapper = styled.div<{ $isClickable: boolean }>`
+  * {
+    cursor: ${({ $isClickable }) => ($isClickable ? 'pointer' : 'default')} !important;
+  }
+`;
+
+export const AuthorDetails = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.2rem;
+`;
+
+export const AuthorName = styled.span<{ $isActive: boolean }>`
+  ${({ theme }) => theme.typography.label2.semibold};
+  color: ${({ theme, $isActive }) => ($isActive ? theme.semantic.label.normal : theme.semantic.label.alternative)};
+`;
+
+export const CommentTime = styled.span`
+  ${({ theme }) => theme.typography.caption1.regular};
+  color: ${({ theme }) => theme.semantic.interaction.inactive};
+`;
+
+export const MenuContainer = styled.div`
+  position: relative;
+`;
+
+export const DotsIcon = styled.svg`
+  color: ${({ theme }) => theme.semantic.label.alternative};
+`;
+
+export const MenuDropdownWrapper = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 10;
+  width: 15rem;
+`;
+
+export const CommentContentWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 1.6rem;
+  align-items: center;
+`;
+
+export const CommentFooter = styled.div`
+  width: 100%;
+`;
+
+export const FooterButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.interaction.inactive};
+
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+
+  svg {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+
+  &:hover {
+    color: ${({ theme }) => theme.semantic.label.normal};
+  }
+`;
+
+export const ReplyFieldContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+  gap: 2.4rem;
+
+  margin-top: 0.8rem;
+`;
+
+export const LikeButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  gap: 0.4rem;
+
+  cursor: pointer;
+`;
+
+export const LikeIcon = styled.div<{ $isLiked: boolean }>`
+  width: 2.4rem;
+  height: 2.4rem;
+  color: ${({ theme, $isLiked }) =>
+    $isLiked ? theme.semantic.background.elevated.alternative : theme.palette.coolNeutral[80]};
+`;
+
+export const LikeCount = styled.span`
+  ${({ theme }) => theme.typography.label1.regular};
+  color: ${({ theme }) => theme.semantic.interaction.inactive};
+`;
+
+export const ArrowIcon = styled.div`
+  color: ${({ theme }) => theme.palette.blue[80]};
+
+  svg {
+    color: ${({ theme }) => theme.palette.blue[80]};
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+`;
+
+export const ChilrenWrpper = styled.div`
+  width: 100%;
+`;
+
+export const ChildrenContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2.4rem;
+
+  width: 100%;
+
+  padding-top: 1.6rem;
+`;
+
+export const EditFieldWrapper = styled.div`
+  width: 100%;
+  flex: 1;
+`;

--- a/src/components/molecules/CommentItem/CommentItem.styled.ts
+++ b/src/components/molecules/CommentItem/CommentItem.styled.ts
@@ -26,6 +26,8 @@ export const CommentCotent = styled.div<{ $isChild: boolean; $isActive: boolean 
   ${({ theme }) => theme.typography.body1.regular};
   background-color: ${({ theme, $isActive }) => ($isActive ? theme.palette.blue[99] : theme.palette.coolNeutral[99])};
   color: ${({ theme, $isActive }) => ($isActive ? theme.semantic.label.normal : theme.palette.coolNeutral[70])};
+  white-space: pre-wrap;
+  word-wrap: break-word;
 
   border-radius: 2rem;
 `;

--- a/src/components/molecules/CommentItem/CommentItem.tsx
+++ b/src/components/molecules/CommentItem/CommentItem.tsx
@@ -187,7 +187,7 @@ export default function CommentItem({
             />
           </S.AvatarWrapper>
 
-          <S.AuthorName 
+          <S.AuthorName
             $isActive={comment.status === 'ACTIVE'}
             $isClickable={!comment.author.isAnonymous}
             onClick={handleAvatarClick}

--- a/src/components/molecules/CommentItem/CommentItem.tsx
+++ b/src/components/molecules/CommentItem/CommentItem.tsx
@@ -29,6 +29,7 @@ interface CommentItemProps {
   isAdmin?: boolean;
   isMine?: boolean;
   isChild?: boolean;
+  isPostAnonymous?: boolean;
   onCommentUpdated?: () => void;
 }
 
@@ -38,6 +39,7 @@ export default function CommentItem({
   isMine = false,
   isAdmin = false,
   isChild = false,
+  isPostAnonymous = false,
   onCommentUpdated,
 }: CommentItemProps) {
   const [likeCount, setLikeCount] = useState(comment.likeCount);
@@ -269,6 +271,7 @@ export default function CommentItem({
             postId={postId}
             placeholder='댓글을 입력해주세요'
             parentId={comment.commentId}
+            showAnonymousCheckbox={isPostAnonymous}
             onSuccess={handleReplySuccess}
           />
         </S.ReplyFieldContainer>
@@ -289,6 +292,7 @@ export default function CommentItem({
                 isMine={childComment.isMine}
                 isAdmin={isAdmin}
                 isChild={true}
+                isPostAnonymous={isPostAnonymous}
                 onCommentUpdated={onCommentUpdated}
               />
             </S.ChildrenContainer>

--- a/src/components/molecules/CommentItem/CommentItem.tsx
+++ b/src/components/molecules/CommentItem/CommentItem.tsx
@@ -187,7 +187,13 @@ export default function CommentItem({
             />
           </S.AvatarWrapper>
 
-          <S.AuthorName $isActive={comment.status === 'ACTIVE'}>{getAuthorName()}</S.AuthorName>
+          <S.AuthorName 
+            $isActive={comment.status === 'ACTIVE'}
+            $isClickable={!comment.author.isAnonymous}
+            onClick={handleAvatarClick}
+          >
+            {getAuthorName()}
+          </S.AuthorName>
           {comment.status === 'ACTIVE' && <S.CommentTime>{formatRelativeKorean(comment.createdAt)}</S.CommentTime>}
         </S.AuthorInfo>
 

--- a/src/components/molecules/CommentItem/CommentItem.tsx
+++ b/src/components/molecules/CommentItem/CommentItem.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { commentApi } from '@/api/commentApis';
+import ArrowRightIcon from '@/assets/icons/arrowturndownright.svg';
+import DotsVerticalIcon from '@/assets/icons/dots-vertical.svg';
+import HeartFill from '@/assets/icons/heart-fill.svg';
+import Heart from '@/assets/icons/heart.svg';
+import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
+import IconButton from '@/components/atoms/IconButton/IconButton';
+import CommentField from '@/components/molecules/CommentField/CommentField';
+import { DropdownList } from '@/components/molecules/DropdownList/DropdownList';
+import { useDeleteCommentLike } from '@/hooks/api/comment/useDeleteCommentLike';
+import { useToggleCommentLike } from '@/hooks/api/comment/useToggleCommentLike';
+import { useDropdown } from '@/hooks/useDropdown';
+import { useAlertModalStore, useSimpleModalStore } from '@/stores/useModalStore';
+import { Comment } from '@/types/comment';
+import { DropdownOption } from '@/types/common';
+import { formatRelativeKorean } from '@/utils/date/formatDay';
+import { formatCountPlus, getDisplayName } from '@/utils/formatText';
+
+import * as S from './CommentItem.styled';
+
+interface CommentItemProps {
+  comment: Comment;
+  postId: string;
+  isAdmin?: boolean;
+  isMine?: boolean;
+  isChild?: boolean;
+  onCommentUpdated?: () => void;
+}
+
+export default function CommentItem({
+  comment,
+  postId,
+  isMine = false,
+  isAdmin = false,
+  isChild = false,
+  onCommentUpdated,
+}: CommentItemProps) {
+  const [likeCount, setLikeCount] = useState(comment.likeCount);
+  const [isLiked, setIsLiked] = useState(comment.isLiked);
+  const [showReplyField, setShowReplyField] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const { open: openAlert } = useAlertModalStore();
+  const { open: openSimpleModal } = useSimpleModalStore();
+  const { isOpen, toggle, close, handleBlur, dropdownRef } = useDropdown();
+
+  const toggleCommentLikeMutation = useToggleCommentLike();
+  const deleteCommentLikeMutation = useDeleteCommentLike();
+
+  const forceDeleteMutation = useMutation({
+    mutationFn: commentApi.deleteComment,
+    onSuccess: () => {
+      openAlert('alert', { message: '댓글이 삭제되었습니다.' });
+      onCommentUpdated?.();
+    },
+    onError: () => {
+      openAlert('alert', { message: '댓글 삭제에 실패했습니다.' });
+    },
+  });
+
+  const getDropdownOptions = (): DropdownOption[] => {
+    const options: DropdownOption[] = [];
+
+    if (isMine) {
+      options.push({ label: '수정하기', value: 'EDIT', color: 'default' });
+      options.push({ label: '삭제하기', value: 'DELETE', color: 'default' });
+    } else if (isAdmin) {
+      options.push({ label: '강제로 삭제', value: 'FORCE_DELETE', color: 'red' });
+    }
+
+    return options;
+  };
+
+  const handleDropdownSelect = (values: Array<string | number>) => {
+    const value = values[0];
+
+    if (value === 'EDIT') {
+      setIsEditing(true);
+      setShowReplyField(false);
+    } else if (value === 'DELETE') {
+      openAlert('communityDelete', {
+        type: 'comment',
+        id: comment.commentId,
+        onConfirm: onCommentUpdated,
+      });
+    } else if (value === 'FORCE_DELETE') {
+      forceDeleteMutation.mutate({ commentId: comment.commentId.toString() });
+    }
+
+    close();
+  };
+
+  const handleAvatarClick = () => {
+    if (!comment.author.isAnonymous) {
+      openSimpleModal('userProfile', {
+        memberId: comment.author.authorId.toString(),
+      });
+    }
+  };
+
+  const handleLikeClick = () => {
+    const originalIsLiked = isLiked;
+    const originalLikeCount = likeCount;
+    const newIsLiked = !isLiked;
+    const newLikeCount = newIsLiked ? likeCount + 1 : likeCount - 1;
+
+    const mutation = originalIsLiked ? deleteCommentLikeMutation : toggleCommentLikeMutation;
+
+    setIsLiked(newIsLiked);
+    setLikeCount(newLikeCount);
+
+    mutation.mutate(comment.commentId.toString(), {
+      onError: () => {
+        setIsLiked(originalIsLiked);
+        setLikeCount(originalLikeCount);
+      },
+    });
+  };
+
+  const handleReplyClick = () => {
+    setShowReplyField(!showReplyField);
+  };
+
+  const handleReplySuccess = () => {
+    setShowReplyField(false);
+    onCommentUpdated?.();
+  };
+
+  const handleEditSuccess = () => {
+    setIsEditing(false);
+    onCommentUpdated?.();
+  };
+
+  const handleEditCancel = () => {
+    setIsEditing(false);
+  };
+
+  const shouldShowMenu = isMine || isAdmin;
+
+  const getCommentContent = () => {
+    switch (comment.status) {
+      case 'ACTIVE':
+        return comment.content;
+      case 'DELETED_BY_USER':
+      case 'DELETED_BY_ADMIN':
+        return '삭제된 댓글이에요';
+      case 'USER_WITHDRAWN':
+        return '댓글을 볼 수 없어요';
+      default:
+        return '댓글을 볼 수 없어요';
+    }
+  };
+
+  const getAuthorName = () => {
+    switch (comment.status) {
+      case 'ACTIVE':
+        return getDisplayName(comment.author.displayName, comment.author.isAnonymous);
+      case 'DELETED_BY_USER':
+      case 'DELETED_BY_ADMIN':
+        return '삭제된 댓글';
+      case 'USER_WITHDRAWN':
+        return '탈퇴한 코그니어';
+      default:
+        return getDisplayName(comment.author.displayName, comment.author.isAnonymous);
+    }
+  };
+
+  return (
+    <S.CommentItemWrapper $isChild={isChild}>
+      <S.CommentHeader>
+        <S.AuthorInfo>
+          <S.AvatarWrapper
+            onClick={handleAvatarClick}
+            $isClickable={!comment.author.isAnonymous}
+          >
+            <AvatarPerson
+              type='icon'
+              size='sm'
+              src={comment.author.profileUrl || undefined}
+            />
+          </S.AvatarWrapper>
+
+          <S.AuthorName $isActive={comment.status === 'ACTIVE'}>{getAuthorName()}</S.AuthorName>
+          {comment.status === 'ACTIVE' && <S.CommentTime>{formatRelativeKorean(comment.createdAt)}</S.CommentTime>}
+        </S.AuthorInfo>
+
+        {shouldShowMenu && comment.status === 'ACTIVE' && (
+          <S.MenuContainer
+            ref={dropdownRef}
+            onBlur={handleBlur}
+            tabIndex={-1}
+          >
+            <IconButton
+              size='3.6rem'
+              variant='normal'
+              interactionVariant='normal'
+              onClick={toggle}
+              aria-label='더보기'
+              aria-haspopup='menu'
+              aria-expanded={isOpen}
+            >
+              <S.DotsIcon>
+                <DotsVerticalIcon />
+              </S.DotsIcon>
+            </IconButton>
+
+            {isOpen && (
+              <S.MenuDropdownWrapper>
+                <DropdownList
+                  options={getDropdownOptions()}
+                  selectedValues={[]}
+                  onSelect={handleDropdownSelect}
+                />
+              </S.MenuDropdownWrapper>
+            )}
+          </S.MenuContainer>
+        )}
+      </S.CommentHeader>
+
+      <S.CommentContentWrapper>
+        {isEditing ? (
+          <S.EditFieldWrapper>
+            <CommentField
+              postId={postId}
+              placeholder='댓글을 수정해주세요'
+              isEdit={true}
+              commentId={comment.commentId.toString()}
+              initialContent={comment.content}
+              onSuccess={handleEditSuccess}
+              onCancel={handleEditCancel}
+            />
+          </S.EditFieldWrapper>
+        ) : (
+          <>
+            <S.CommentCotent
+              $isChild={isChild}
+              $isActive={comment.status === 'ACTIVE'}
+            >
+              {getCommentContent()}
+            </S.CommentCotent>
+            {comment.status === 'ACTIVE' && (
+              <S.LikeButton onClick={handleLikeClick}>
+                <S.LikeIcon $isLiked={isLiked}>{isLiked ? <HeartFill /> : <Heart />}</S.LikeIcon>
+                <S.LikeCount>{formatCountPlus(likeCount)}</S.LikeCount>
+              </S.LikeButton>
+            )}
+          </>
+        )}
+      </S.CommentContentWrapper>
+
+      {!isChild && !isEditing && comment.status === 'ACTIVE' && (
+        <S.CommentFooter>
+          <S.FooterButton onClick={handleReplyClick}>{showReplyField ? '취소하기' : '답글 달기'}</S.FooterButton>
+        </S.CommentFooter>
+      )}
+
+      {showReplyField && !isEditing && comment.status === 'ACTIVE' && (
+        <S.ReplyFieldContainer>
+          <S.ArrowIcon>
+            <ArrowRightIcon />
+          </S.ArrowIcon>
+
+          <CommentField
+            postId={postId}
+            placeholder='댓글을 입력해주세요'
+            parentId={comment.commentId}
+            onSuccess={handleReplySuccess}
+          />
+        </S.ReplyFieldContainer>
+      )}
+
+      {comment.children && comment.children.length > 0 && (
+        <S.ChilrenWrpper>
+          {comment.children.map((childComment) => (
+            <S.ChildrenContainer key={childComment.commentId}>
+              <S.ArrowIcon>
+                <ArrowRightIcon />
+              </S.ArrowIcon>
+
+              <CommentItem
+                key={childComment.commentId}
+                comment={childComment}
+                postId={postId}
+                isMine={childComment.isMine}
+                isAdmin={isAdmin}
+                isChild={true}
+                onCommentUpdated={onCommentUpdated}
+              />
+            </S.ChildrenContainer>
+          ))}
+        </S.ChilrenWrpper>
+      )}
+    </S.CommentItemWrapper>
+  );
+}

--- a/src/components/molecules/CommentList/CommentList.styled.ts
+++ b/src/components/molecules/CommentList/CommentList.styled.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const CommentListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
+
+export const EmptyMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  text-align: center;
+`;
+
+export const EmptyText = styled.p`
+  ${({ theme }) => theme.typography.body1.regular};
+  color: ${({ theme }) => theme.semantic.label.assistive};
+  margin: 0;
+`;
+
+export const LoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+`;

--- a/src/components/molecules/CommentList/CommentList.tsx
+++ b/src/components/molecules/CommentList/CommentList.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import LoadingSpinner from '@/components/atoms/LoadingSpinner/LoadingSpinner';
+import CommentItem from '@/components/molecules/CommentItem/CommentItem';
+import { Comment } from '@/types/comment';
+
+import * as S from './CommentList.styled';
+
+interface CommentListProps {
+  comments: Comment[];
+  postId: string;
+  isLoading?: boolean;
+  isAdmin?: boolean;
+  onCommentUpdated?: () => void;
+}
+
+export default function CommentList({
+  comments,
+  postId,
+  isLoading = false,
+  isAdmin = false,
+  onCommentUpdated,
+}: CommentListProps) {
+  if (isLoading) {
+    return (
+      <S.LoadingWrapper>
+        <LoadingSpinner />
+      </S.LoadingWrapper>
+    );
+  }
+
+  if (!comments || comments.length === 0) return null;
+
+  return (
+    <S.CommentListWrapper>
+      {comments
+        .filter((comment) => comment)
+        .map((comment) => (
+          <CommentItem
+            key={comment.commentId}
+            comment={comment}
+            postId={postId}
+            isMine={comment.isMine || false}
+            isAdmin={isAdmin}
+            onCommentUpdated={onCommentUpdated}
+          />
+        ))}
+    </S.CommentListWrapper>
+  );
+}

--- a/src/components/molecules/CommentList/CommentList.tsx
+++ b/src/components/molecules/CommentList/CommentList.tsx
@@ -11,6 +11,7 @@ interface CommentListProps {
   postId: string;
   isLoading?: boolean;
   isAdmin?: boolean;
+  isPostAnonymous?: boolean;
   onCommentUpdated?: () => void;
 }
 
@@ -19,6 +20,7 @@ export default function CommentList({
   postId,
   isLoading = false,
   isAdmin = false,
+  isPostAnonymous = false,
   onCommentUpdated,
 }: CommentListProps) {
   if (isLoading) {
@@ -42,6 +44,7 @@ export default function CommentList({
             postId={postId}
             isMine={comment.isMine || false}
             isAdmin={isAdmin}
+            isPostAnonymous={isPostAnonymous}
             onCommentUpdated={onCommentUpdated}
           />
         ))}

--- a/src/components/organisms/Modal/CommunityDelete/CommunityDelete.tsx
+++ b/src/components/organisms/Modal/CommunityDelete/CommunityDelete.tsx
@@ -37,7 +37,7 @@ export default function CommunityDelete({ type, id, onConfirm }: CommunityDelete
 
   return (
     <S.CommunityDelete>
-      <S.Title>{isPost ? '글을 삭제하시겠습니까?' : '댓글을 삭제하시겠습니까?'}</S.Title>
+      <S.Title>{isPost ? '글을 지울까요?' : '댓글을 삭제하시겠어요?'}</S.Title>
 
       <S.ButtonWrapper>
         <OutlinedButton

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -92,7 +92,12 @@ export const END_POINTS_V1 = {
     DELETE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}`,
   },
   COMMENTS: {
+    CREATE: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}/comments`,
+    LIST: (postId: string) => `${BASE_PATH_V1.POSTS}/${postId}/comments`,
+    UPDATE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}`,
     DELETE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}`,
+    LIKE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}/likes`,
+    DELETE_LIKE: (commentId: string) => `${BASE_PATH_V1.COMMENTS}/${commentId}/likes`,
   },
 
   ADMIN: {

--- a/src/hooks/api/comment/useCreateComment.ts
+++ b/src/hooks/api/comment/useCreateComment.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { HTTPError } from '@/api/axios/errors/HTTPError';
+import { commentApi } from '@/api/commentApis';
+import { POST_QUERY_KEYS } from '@/constants/queryKeys';
+import { useAlertModalStore, useAppModalStore } from '@/stores/useModalStore';
+import { CreateCommentRequest } from '@/types/comment';
+
+export const useCreateComment = (postId: string) => {
+  const queryClient = useQueryClient();
+  const { open: openAlert } = useAlertModalStore();
+  const { open: openModal } = useAppModalStore();
+
+  const mutation = useMutation({
+    mutationFn: (request: CreateCommentRequest) => commentApi.createComment(postId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST, postId] });
+      queryClient.invalidateQueries({ queryKey: ['comments', postId] });
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '사용자를 찾을 수 없습니다.' });
+          break;
+        case 'FORBIDDEN_ERROR':
+          openAlert('alert', { message: '사용자 권한이 없습니다.' });
+          break;
+        case 'TOKEN_INVALID_ERROR':
+        case 'ACCESS_TOKEN_EMPTY_ERROR':
+          openModal('login');
+          break;
+        case 'POST_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '게시물을 찾을 수 없습니다.' });
+          break;
+        case 'POST_NOT_ALLOWED_ANONYMOUS_COMMENT_ERROR':
+          openAlert('alert', { message: '익명 게시글에만 익명 댓글을 달 수 있습니다.' });
+          break;
+        case 'PARENT_COMMENT_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '부모 댓글을 찾을 수 없습니다.' });
+          break;
+        case 'CONTENT_NOTBLANK_ERROR':
+          openAlert('alert', { message: '댓글 내용을 1자 이상 작성해주세요.' });
+          break;
+        case 'CONTENT_SIZE_ERROR':
+          openAlert('alert', { message: '댓글 내용은 1000자 이하여야 합니다.' });
+          break;
+        case 'MENTIONED_MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '멘션된 사용자를 찾을 수 없습니다.' });
+          break;
+        default:
+          openAlert('error', { message: error.message || '댓글 작성에 실패했습니다.' });
+          break;
+      }
+    },
+  });
+
+  return {
+    createComment: mutation.mutate,
+    isLoading: mutation.isPending,
+    isError: mutation.isError,
+    error: mutation.error,
+  };
+};

--- a/src/hooks/api/comment/useDeleteComment.ts
+++ b/src/hooks/api/comment/useDeleteComment.ts
@@ -15,7 +15,7 @@ export const useDeleteCommentMutation = () => {
     mutationFn: commentApi.deleteComment,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...ADMIN_QUERY_KEYS.COMMENT_LIST] });
-      // TODO: 댓글 목록 조회도 캐시 무효화 (추후 Optimistic Update로 개선)
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
       open('alert', { message: '댓글이 삭제되었습니다.' });
     },
 

--- a/src/hooks/api/comment/useDeleteCommentLike.ts
+++ b/src/hooks/api/comment/useDeleteCommentLike.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { HTTPError } from '@/api/axios/errors/HTTPError';
+import { commentApi } from '@/api/commentApis';
+import { useAlertModalStore } from '@/stores/useModalStore';
+
+export const useDeleteCommentLike = () => {
+  const queryClient = useQueryClient();
+  const { open: openAlert } = useAlertModalStore();
+
+  const mutation = useMutation({
+    mutationFn: commentApi.deleteCommentLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '사용자를 찾을 수 없습니다.' });
+          break;
+        case 'FORBIDDEN_ERROR':
+          openAlert('alert', { message: '사용자 권한이 없습니다.' });
+          break;
+        case 'COMMENT_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '댓글을 찾을 수 없습니다.' });
+          break;
+        case 'NOT_LIKED_ERROR':
+          openAlert('alert', { message: '좋아요를 하지 않은 댓글입니다.' });
+          break;
+        default:
+          openAlert('error', { message: error.message || '댓글 좋아요 취소에 실패했습니다.' });
+          break;
+      }
+    },
+  });
+
+  return mutation;
+};

--- a/src/hooks/api/comment/useGetComments.ts
+++ b/src/hooks/api/comment/useGetComments.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { commentApi } from '@/api/commentApis';
+import { CommentListRequest } from '@/types/comment';
+
+export const useGetComments = (postId: string, params: CommentListRequest = {}) => {
+  return useInfiniteQuery({
+    queryKey: ['comments', postId, params],
+    queryFn: ({ pageParam = undefined }) =>
+      commentApi.getCommentList(postId, {
+        ...params,
+        cursor: pageParam,
+        pageSize: 5,
+      }),
+    getNextPageParam: (lastPage) => (lastPage.isLast ? undefined : lastPage.nextCursor),
+    initialPageParam: undefined as number | undefined,
+    enabled: !!postId,
+  });
+};

--- a/src/hooks/api/comment/useToggleCommentLike.ts
+++ b/src/hooks/api/comment/useToggleCommentLike.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { HTTPError } from '@/api/axios/errors/HTTPError';
+import { commentApi } from '@/api/commentApis';
+import { useAlertModalStore } from '@/stores/useModalStore';
+
+export const useToggleCommentLike = () => {
+  const queryClient = useQueryClient();
+  const { open: openAlert } = useAlertModalStore();
+
+  const mutation = useMutation({
+    mutationFn: commentApi.toggleCommentLike,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '사용자를 찾을 수 없습니다.' });
+          break;
+        case 'INTERNAL_SERVER_ERROR':
+          openAlert('alert', { message: '서버 내부 오류가 발생했습니다.' });
+          break;
+        case 'FORBIDDEN_ERROR':
+          openAlert('alert', { message: '사용자 권한이 없습니다.' });
+          break;
+        case 'COMMENT_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '댓글을 찾을 수 없습니다.' });
+          break;
+        case 'ALREADY_LIKED_ERROR':
+          openAlert('alert', { message: '이미 좋아요한 댓글입니다.' });
+          break;
+        default:
+          openAlert('error', { message: error.message || '댓글 좋아요에 실패했습니다.' });
+          break;
+      }
+    },
+  });
+
+  return mutation;
+};

--- a/src/hooks/api/comment/useUpdateComment.ts
+++ b/src/hooks/api/comment/useUpdateComment.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { HTTPError } from '@/api/axios/errors/HTTPError';
+import { commentApi } from '@/api/commentApis';
+import { useAlertModalStore } from '@/stores/useModalStore';
+import { UpdateCommentRequest } from '@/types/comment';
+
+export const useUpdateComment = () => {
+  const queryClient = useQueryClient();
+  const { open: openAlert } = useAlertModalStore();
+
+  const mutation = useMutation({
+    mutationFn: ({ commentId, data }: { commentId: string; data: UpdateCommentRequest }) =>
+      commentApi.updateComment(commentId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
+    },
+    onError: (error: HTTPError) => {
+      switch (error.code) {
+        case 'FORBIDDEN_ERROR':
+          openAlert('alert', { message: '사용자 권한이 없습니다.' });
+          break;
+        case 'COMMENT_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '댓글을 찾을 수 없습니다.' });
+          break;
+        case 'MEMBER_NOT_FOUND_ERROR':
+          openAlert('alert', { message: '사용자를 찾을 수 없습니다.' });
+          break;
+        case 'POST_NOT_ALLOWED_ANONYMOUS_COMMENT_ERROR':
+          openAlert('alert', { message: '익명 게시글에만 익명 댓글을 달 수 있습니다.' });
+          break;
+        case 'COMMENT_FORBIDDEN_ERROR':
+          openAlert('alert', { message: '본인이 작성한 댓글만 수정/삭제가 가능합니다.' });
+          break;
+        case 'COMMENT_ALREADY_DELETED_ERROR':
+          openAlert('alert', { message: '이미 삭제된 댓글입니다.' });
+          break;
+        case 'WITHDRAWN_USER_COMMENT_ERROR':
+          openAlert('alert', { message: '탈퇴한 사용자의 댓글입니다.' });
+          break;
+        case 'COMMENT_HIDDEN_ERROR':
+          openAlert('alert', { message: '숨김 처리된 댓글입니다.' });
+          break;
+        default:
+          openAlert('error', { message: error.message || '댓글 수정에 실패했습니다.' });
+          break;
+      }
+    },
+  });
+
+  return mutation;
+};

--- a/src/hooks/api/post/useCreatePost.ts
+++ b/src/hooks/api/post/useCreatePost.ts
@@ -18,7 +18,10 @@ export const useCreatePostMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...POST_QUERY_KEYS.POST] });
 
-      router.push(`/community`);
+      openAlert('alert', {
+        message: '작성되었어요!',
+        onConfirm: () => router.push(`/community`),
+      });
     },
     onError: (error: HTTPError) => {
       switch (error.code) {

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,7 +1,7 @@
 import { ApiResponse, CursorPaginationResult } from './api';
 import { PostCategory, PostSummary } from './post';
 
-export type CommentStatus = 'ACTIVE' | 'DELETED_BY_USER' | 'DELETED_BY_ADMIN' | 'USER_WITHDRAWN';
+export type CommentStatus = 'ACTIVE' | 'DELETED_BY_USER' | 'DELETED_BY_ADMIN' | 'USER_WITHDRAWN' | 'HIDDEN_BY_ADMIN';
 
 export interface CommentAuthor {
   authorId: number;

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,3 +1,4 @@
+import { ApiResponse, CursorPaginationResult } from './api';
 import { PostCategory, PostSummary } from './post';
 
 export type CommentStatus = 'ACTIVE' | 'DELETED_BY_USER' | 'DELETED_BY_ADMIN' | 'USER_WITHDRAWN';
@@ -9,14 +10,59 @@ export interface CommentAuthor {
   profileUrl: string;
 }
 
+export interface CommentMyStatus {
+  isLiked: boolean;
+}
+
 export type Comment = {
   commentId: number;
+  content: string;
   comment: string;
   parentId?: number;
   status: CommentStatus;
   post: PostSummary;
   category: PostCategory;
   author: CommentAuthor;
+  isLiked: boolean;
+  isMine: boolean;
+  likeCount: number;
+  myStatus: CommentMyStatus;
+  children?: Comment[];
   createdAt: string;
   updatedAt: string;
 };
+
+export type CreateCommentRequest = {
+  parentId?: number;
+  content: string;
+  isAnonymous: boolean;
+  mentionedList: number[];
+};
+
+export type CreateCommentResponse = ApiResponse & {
+  result: Comment;
+};
+
+export type UpdateCommentRequest = {
+  content: string;
+  isAnonymous: boolean;
+  mentionedList: number[];
+};
+
+export type UpdateCommentResponse = ApiResponse & {
+  result: Comment;
+};
+
+export type CommentListRequest = {
+  categoryId?: number[];
+  pageSize?: number;
+  cursor?: number;
+};
+
+export type CommentListResponse = ApiResponse & {
+  result: CursorPaginationResult<Comment>;
+};
+
+export interface DeleteCommentLikeResponse extends ApiResponse {
+  result?: [];
+}


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #https://github.com/Oncognier/cogroom-fe/issues/463

## 📋 작업 내용

- 댓글 조회/수정/삭제/좋아요 기능
- 대댓글 조회/수정/삭제/좋아요 기능
- 부모 댓글 5개를 기준으로 무한스크롤 구현
- response data 중 status(댓글상태)에 따른 UI 구현
- 댓글/대댓글 createdAt 기준 내림차순 정렬
- 댓글 삭제 시 '삭제하시겠어요?' 컨펌 얼럿 추가
- 게시글 등록 시 '작성되었어요!' 얼럿 추가 
- 익명 게시글에 익명 댓글/대댓글 기능 추가 




https://github.com/user-attachments/assets/473eb5de-7334-46e8-8d9b-f45746b908ed


https://github.com/user-attachments/assets/30f9bf02-b0c8-4e48-848c-faf272fad1b6


익명 댓글 /대댓글


https://github.com/user-attachments/assets/98a6b2d0-01b2-436f-bfbd-20d929b5cda8



## 🛠️ 특이 사항

- CommentItem 은 추후 리팩토링 해놓겠읍니다..

## ⚡️ 리뷰 요구사항 (선택)
