### PR TITLE
[FEAT] daily answer character limit #487

### DIFF
--- a/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/Question.tsx
@@ -7,10 +7,10 @@ import { DAILY_MAX_LENGTH } from '@/constants/common';
 import { DEFAULT_QUESTION_BACKGROUND } from '@/constants/image';
 import { useEditDailyAnswerMutation } from '@/hooks/api/daily/useEditDailyAnswer';
 import { useSubmitDailyAnswerMutation } from '@/hooks/api/daily/useSubmitDailyAnswer';
-import { useTextLimiter } from '@/hooks/useTextLimiter';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppModalStore, useAlertModalStore } from '@/stores/useModalStore';
 
+import InputCount from './_components/InputCount';
 import * as S from './Question.styled';
 
 interface QuestionProps {
@@ -40,12 +40,7 @@ export default function Question({
   const { open } = useAppModalStore();
   const { open: openAlertModal } = useAlertModalStore();
 
-  const {
-    value: answerValue,
-    setValue: setAnswerValue,
-    isShaking,
-    isOverLimit,
-  } = useTextLimiter(DAILY_MAX_LENGTH, answer ?? '');
+  const [answerValue, setAnswerValue] = useState<string>(answer ?? '');
 
   const handleInput = () => {
     const el = textareaRef.current;
@@ -125,12 +120,11 @@ export default function Question({
 
         <S.SubmitGroup>
           {!readOnlyMode && (
-            <S.CountValue
-              isHundredOver={isOverLimit}
-              isShaking={isShaking}
-            >
-              {answerValue.length}/{DAILY_MAX_LENGTH - 1}
-            </S.CountValue>
+            <InputCount
+              maxLength={DAILY_MAX_LENGTH}
+              value={answerValue}
+              onChange={setAnswerValue}
+            />
           )}
           {!hideSubmitButton && (
             <S.Button onClick={isAnswered ? handleEdit : handleSubmit}>{isAnswered ? '수정하기' : '제출하기'}</S.Button>

--- a/src/app/(shared)/(standard)/daily/_components/Question/_components/InputCount.styled.ts
+++ b/src/app/(shared)/(standard)/daily/_components/Question/_components/InputCount.styled.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+import { shakeAnimation } from '@/styles/helpers/animations';
+
+export const InputCount = styled.div<{ isOverLimit?: boolean; isShaking?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1.2rem;
+
+  ${({ theme }) => theme.typography.label2.regular}
+  color: ${({ theme, isOverLimit }) =>
+    isOverLimit ? theme.semantic.status.destructive : theme.semantic.primary.normal};
+
+  ${({ isShaking }) => isShaking && shakeAnimation}
+`;

--- a/src/app/(shared)/(standard)/daily/_components/Question/_components/InputCount.tsx
+++ b/src/app/(shared)/(standard)/daily/_components/Question/_components/InputCount.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useTextLimiter } from '@/hooks/useTextLimiter';
+
+import * as S from './InputCount.styled';
+
+interface InputCountProps {
+  maxLength: number;
+  value: string;
+  onChange: (limitedValue: string) => void;
+}
+
+export default function InputCount({ maxLength, value, onChange }: InputCountProps) {
+  const { isShaking, isOverLimit } = useTextLimiter(maxLength, value, onChange);
+
+  return (
+    <S.InputCount
+      isOverLimit={isOverLimit}
+      isShaking={isShaking}
+    >
+      {value.length}/{maxLength - 1}
+    </S.InputCount>
+  );
+}

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -174,7 +174,7 @@ export type WithdrawStep = (typeof WITHDRAW_STEP)[keyof typeof WITHDRAW_STEP];
 /* ---------- UI/기능 관련 ---------- */
 export const WEEK_DAYS = ['월', '화', '수', '목', '금', '토', '일'] as const;
 export const PAGINATION_VISIBLE_RANGE = 5;
-export const DAILY_MAX_LENGTH = 101;
+export const DAILY_MAX_LENGTH = 201;
 
 export const SPRITE_WIDTH = 257;
 export const FRAME_COUNT = 9;

--- a/src/hooks/useTextLimiter.ts
+++ b/src/hooks/useTextLimiter.ts
@@ -1,22 +1,24 @@
-import { useState, useEffect } from 'react';
+'use client';
+
+import { useEffect, useMemo } from 'react';
 
 import { useShake } from './useShake';
 
-export function useTextLimiter(maxLength: number, initialValue: string = '') {
-  const [value, setValue] = useState(initialValue);
+export function useTextLimiter(maxLength: number, value: string, onChange: (limitedValue: string) => void) {
   const { isShaking, triggerShake } = useShake();
 
   useEffect(() => {
     if (value.length > maxLength) {
-      setValue(value.slice(0, maxLength));
+      const limitedValue = value.slice(0, maxLength);
       triggerShake();
+      onChange(limitedValue);
     }
-  }, [value, maxLength, triggerShake]);
+  }, [value, maxLength, triggerShake, onChange]);
+
+  const isOverLimit = useMemo(() => value.length >= maxLength, [value, maxLength]);
 
   return {
-    value,
-    setValue,
     isShaking,
-    isOverLimit: value.length >= maxLength,
+    isOverLimit,
   };
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #487 

## 📋 작업 내용

- 글자수 100에서 200으로 변경
추후 구독 상태에 따라 달라지는건 나중에 하는걸로 했고 뭔가 지금 있는 글자수 제한 로직이 너무 의존성이 높은것 같아서 낮춰보려는 노력을 했는데
잘 된건지 모르겠네요 .. 어려워요..  더 좋은 방식 계속 생각해볼게요.

<img width="972" height="558" alt="image" src="https://github.com/user-attachments/assets/7000b69b-ed56-4ad3-8998-5835ca2bd129" />

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
저는 이게 나중에 다른 글자수 제한 (커뮤니티 - 댓글, 게시판 제목) 과 같은 글자수 제한이 있는 곳에도 쓰일 줄 알고 그 상황을 대비해 만든거였는데 음 ... 여기에만 쓰는거면 이렇게 안하는 것도 맞지 않나 싶기도 하네요.

백엔드는 아직 200자 제한으로 올린것 같지 않아서 지금은 아마 100자 제한으로 밖에 제출 및 수정이 가능할 겁니다.
