### PR TITLE
[FEAT] CommentListRow 탭, 모바일 반응형 구현 #504

### DIFF
--- a/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.styled.ts
@@ -2,10 +2,12 @@
 
 import styled from '@emotion/styled';
 
+import { mqMax } from '@/styles/foundation';
+
 export const CommentListRow = styled.div`
   display: flex;
   justify-content: space-between;
-  gap: 2.2rem;
+  gap: 0.8rem;
 
   width: 100%;
   padding: 2.4rem 3.2rem;
@@ -13,6 +15,10 @@ export const CommentListRow = styled.div`
   cursor: pointer;
 
   border-bottom: 1px solid ${({ theme }) => theme.semantic.line.normal};
+
+  ${mqMax.desktop} {
+    flex-direction: column;
+  }
 `;
 
 export const CommentLeft = styled.div`
@@ -48,6 +54,17 @@ export const CommentRight = styled.div`
   gap: 0.8rem;
 
   max-width: 40.4rem;
+
+  ${mqMax.desktop} {
+    max-width: none;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  ${mqMax.tablet} {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 `;
 
 export const Post = styled.div`


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #504 

## 📋 작업 내용

- CommentListRow 탭, 모바일 반응형 구현

<img width="651" height="292" alt="스크린샷 2025-09-24 오후 4 11 18" src="https://github.com/user-attachments/assets/d35e18cb-9530-4401-ad11-a2d90e7ef69b" />

<img width="709" height="374" alt="스크린샷 2025-09-24 오후 4 11 01" src="https://github.com/user-attachments/assets/73d361a1-4e27-4d56-852e-634c02dd7905" />

<img width="543" height="468" alt="스크린샷 2025-09-24 오후 4 11 47" src="https://github.com/user-attachments/assets/acd6ab0b-ecd6-42c7-a0f5-b9277e0c4d13" />

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
