### PR TITLE
[FEAT] 마이페이지 반응형 추가 #515

### DIFF
--- a/src/components/organisms/PostCard/PostCard.styled.ts
+++ b/src/components/organisms/PostCard/PostCard.styled.ts
@@ -1,105 +1,17 @@
-'use client';
-
 import styled from '@emotion/styled';
 
-export const PostCard = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 2.2rem;
+import { mqMax } from '@/styles/foundation';
+
+export const DesktopOnly = styled.div`
+  ${mqMax.tablet} {
+    display: none;
+  }
 `;
 
-export const CardContainer = styled.div`
-  display: flex;
-  gap: 2.2rem;
+export const MobileOnly = styled.div`
+  display: none;
 
-  width: 100%;
-
-  cursor: pointer;
-`;
-
-export const ThumbnailWrapper = styled.div`
-  flex-shrink: 0;
-
-  width: 17.4rem;
-`;
-
-export const Body = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  width: 100%;
-  min-width: 0;
-`;
-
-export const Main = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 2.4rem;
-
-  min-width: 0;
-`;
-
-export const MainHeader = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-
-  min-width: 0;
-`;
-
-export const UserProfile = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-
-  width: fit-content;
-`;
-
-export const Nickname = styled.p`
-  ${({ theme }) => theme.typography.caption2.regular};
-  color: ${({ theme }) => theme.semantic.label.normal};
-`;
-
-export const Title = styled.p`
-  ${({ theme }) => theme.typography.headline2.semibold};
-  color: ${({ theme }) => theme.semantic.label.normal};
-  min-width: 0;
-  max-width: 36.7rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
-export const MetaRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-
-  padding-bottom: 0.6rem;
-`;
-
-export const Aside = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1.2rem;
-  flex-shrink: 0;
-
-  height: 100%;
-
-  cursor: default;
-`;
-
-export const SideMeta = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.4rem;
-`;
-
-export const MetaText = styled.div`
-  ${({ theme }) => theme.typography.caption1.regular};
-  color: ${({ theme }) => theme.semantic.interaction.inactive};
+  ${mqMax.tablet} {
+    display: block;
+  }
 `;

--- a/src/components/organisms/PostCard/PostCard.tsx
+++ b/src/components/organisms/PostCard/PostCard.tsx
@@ -1,170 +1,27 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { Post } from '@/types/post';
 
-import BookmarkFill from '@/assets/icons/bookmark-fill.svg';
-import Bookmark from '@/assets/icons/bookmark.svg';
-import CommentFill from '@/assets/icons/comment-fill.svg';
-import Comment from '@/assets/icons/comment.svg';
-import HeartFill from '@/assets/icons/heart-fill.svg';
-import Heart from '@/assets/icons/heart.svg';
-import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
-import Checkbox from '@/components/atoms/Checkbox/Checkbox';
-import SolidTag from '@/components/atoms/SolidTag/SolidTag';
-import Thumbnail from '@/components/atoms/Thumbnail/Thumbnail';
-import { POST_CATEGORY_META, PostCategory } from '@/constants/common';
-import { DEFAULT_THUMBNAIL } from '@/constants/image';
-import { useTogglePostLike } from '@/hooks/api/post/useTogglePostLike';
-import { useTogglePostSave } from '@/hooks/api/post/useTogglePostSave';
-import { useAuthStore } from '@/stores/useAuthStore';
-import { useAppModalStore, useSimpleModalStore } from '@/stores/useModalStore';
-import type { Post } from '@/types/post';
-import { formatRelativeKorean } from '@/utils/date/formatDay';
-import { formatCountPlus, getDisplayName } from '@/utils/formatText';
-
-import MetaItem from './MetaItem/MetaItem';
 import * as S from './PostCard.styled';
+import PostCardDesktop from './PostCardDesktop/PostCardDesktop';
+import PostCardMobile from './PostCardMobile/PostCardMobile';
 
-interface PostCardProps {
+export interface PostCardProps {
   post: Post;
   isEdit?: boolean;
   isSelected?: boolean;
   onToggleSelect?: (checked: boolean) => void;
 }
 
-export default function PostCard({ post, isEdit = false, isSelected = false, onToggleSelect }: PostCardProps) {
-  const router = useRouter();
-  const { open: openAppModal } = useAppModalStore();
-  const { open: openSimpleModal } = useSimpleModalStore();
-  const isAuth = useAuthStore((s) => s.isAuth());
-
-  const {
-    postId,
-    title,
-    thumbnailUrl,
-    category,
-    author,
-    myStatus,
-    viewCount: viewCountProp,
-    likeCount: likeCountProp,
-    commentCount,
-    saveCount: saveCountProp,
-    createdAt,
-  } = post;
-
-  const categoryMeta = POST_CATEGORY_META[category.name as PostCategory];
-
-  const isLiked = Boolean(myStatus?.isLiked);
-  const isSaved = Boolean(myStatus?.isSaved);
-  const likeCount = likeCountProp ?? 0;
-  const saveCount = saveCountProp ?? 0;
-
-  const togglePostLikeMutation = useTogglePostLike();
-  const togglePostSaveMutation = useTogglePostSave();
-
-  const handleCardClick = () => {
-    if (isAuth) {
-      router.push(`/community/post/${postId}`);
-      return;
-    }
-    openAppModal('login');
-  };
-
-  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
-
-  const handleProfile = (e: React.SyntheticEvent) => {
-    stop(e);
-    if (author?.authorId && !author.isAnonymous) {
-      openSimpleModal('userProfile', { memberId: String(author.authorId) });
-    }
-  };
-
-  const onToggleLike = () => {
-    if (togglePostLikeMutation.isPending) return;
-    togglePostLikeMutation.mutate({ postId: String(postId), isLiked });
-  };
-
-  const onToggleSave = () => {
-    if (togglePostSaveMutation.isPending) return;
-    togglePostSaveMutation.mutate({ postId: String(postId), isSaved });
-  };
-
+export default function PostCard(props: PostCardProps) {
   return (
-    <S.PostCard onClick={handleCardClick}>
-      {isEdit && (
-        <Checkbox
-          isChecked={!!isSelected}
-          onToggle={(checked) => onToggleSelect?.(checked)}
-          size='sm'
-          interactionVariant='normal'
-        />
-      )}
-
-      <S.CardContainer>
-        <S.ThumbnailWrapper>
-          <Thumbnail
-            ratio='16_10'
-            src={thumbnailUrl || DEFAULT_THUMBNAIL}
-            radius
-          />
-        </S.ThumbnailWrapper>
-
-        <S.Body>
-          <S.Main>
-            <S.MainHeader>
-              <S.Title>{title}</S.Title>
-              {author && (
-                <S.UserProfile onClick={handleProfile}>
-                  <AvatarPerson
-                    type='icon'
-                    size='xsm'
-                    src={author.profileUrl || undefined}
-                  />
-                  <S.Nickname>{getDisplayName(author.displayName, author.isAnonymous)}</S.Nickname>
-                </S.UserProfile>
-              )}
-            </S.MainHeader>
-
-            <S.MetaRow>
-              <MetaItem
-                count={likeCount}
-                icon={<Heart />}
-                fillIcon={<HeartFill />}
-                isActive={isLiked}
-                onClick={onToggleLike}
-                disabled={togglePostLikeMutation.isPending}
-              />
-              <MetaItem
-                count={commentCount || 0}
-                icon={<Comment />}
-                fillIcon={<CommentFill />}
-                isActive={false}
-              />
-              <MetaItem
-                count={saveCount}
-                icon={<Bookmark />}
-                fillIcon={<BookmarkFill />}
-                isActive={isSaved}
-                onClick={onToggleSave}
-                disabled={togglePostSaveMutation.isPending}
-              />
-            </S.MetaRow>
-          </S.Main>
-
-          <S.Aside onClick={stop}>
-            {categoryMeta && (
-              <SolidTag
-                label={categoryMeta.label}
-                color={categoryMeta.color}
-              />
-            )}
-            <S.SideMeta>
-              <S.MetaText>조회수 {formatCountPlus(viewCountProp || 0)}</S.MetaText>
-              <S.MetaText>{formatRelativeKorean(createdAt)}</S.MetaText>
-            </S.SideMeta>
-          </S.Aside>
-        </S.Body>
-      </S.CardContainer>
-    </S.PostCard>
+    <>
+      <S.DesktopOnly>
+        <PostCardDesktop {...props} />
+      </S.DesktopOnly>
+      <S.MobileOnly>
+        <PostCardMobile {...props} />
+      </S.MobileOnly>
+    </>
   );
 }

--- a/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.stories.tsx
+++ b/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.stories.tsx
@@ -1,18 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import PostCard from './PostCard';
+import PostCardDesktop from './PostCardDesktop';
 
 const meta = {
-  title: 'components/organisms/PostCard',
-  component: PostCard,
+  title: 'components/organisms/PostCardDesktop',
+  component: PostCardDesktop,
   tags: ['autodocs'],
   argTypes: {
     isEdit: { control: 'boolean' },
     isSelected: { control: 'boolean' },
     onToggleSelect: { action: 'toggle-select' },
   },
-} satisfies Meta<typeof PostCard>;
+} satisfies Meta<typeof PostCardDesktop>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -115,7 +115,7 @@ export const EditMode: Story = {
   render: (args) => {
     const [selected, setSelected] = useState(args.isSelected ?? false);
     return (
-      <PostCard
+      <PostCardDesktop
         {...args}
         isSelected={selected}
         onToggleSelect={(checked) => setSelected(checked)}

--- a/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.styled.ts
+++ b/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.styled.ts
@@ -1,0 +1,105 @@
+'use client';
+
+import styled from '@emotion/styled';
+
+export const PostCardDesktop = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2.2rem;
+`;
+
+export const CardContainer = styled.div`
+  display: flex;
+  gap: 2.2rem;
+
+  width: 100%;
+
+  cursor: pointer;
+`;
+
+export const ThumbnailWrapper = styled.div`
+  flex-shrink: 0;
+
+  width: 17.4rem;
+`;
+
+export const Body = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  min-width: 0;
+`;
+
+export const Main = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 2.4rem;
+
+  min-width: 0;
+`;
+
+export const MainHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+
+  min-width: 0;
+`;
+
+export const UserProfile = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+
+  width: fit-content;
+`;
+
+export const Nickname = styled.p`
+  ${({ theme }) => theme.typography.caption2.regular};
+  color: ${({ theme }) => theme.semantic.label.normal};
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typography.headline2.semibold};
+  color: ${({ theme }) => theme.semantic.label.normal};
+  min-width: 0;
+  max-width: 36.7rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const MetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+
+  padding-bottom: 0.6rem;
+`;
+
+export const Aside = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.2rem;
+  flex-shrink: 0;
+
+  height: 100%;
+
+  cursor: default;
+`;
+
+export const SideMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+`;
+
+export const MetaText = styled.div`
+  ${({ theme }) => theme.typography.caption1.regular};
+  color: ${({ theme }) => theme.semantic.interaction.inactive};
+`;

--- a/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
+++ b/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import BookmarkFill from '@/assets/icons/bookmark-fill.svg';
+import Bookmark from '@/assets/icons/bookmark.svg';
+import CommentFill from '@/assets/icons/comment-fill.svg';
+import Comment from '@/assets/icons/comment.svg';
+import HeartFill from '@/assets/icons/heart-fill.svg';
+import Heart from '@/assets/icons/heart.svg';
+import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
+import Checkbox from '@/components/atoms/Checkbox/Checkbox';
+import SolidTag from '@/components/atoms/SolidTag/SolidTag';
+import Thumbnail from '@/components/atoms/Thumbnail/Thumbnail';
+import { POST_CATEGORY_META, PostCategory } from '@/constants/common';
+import { DEFAULT_THUMBNAIL } from '@/constants/image';
+import { useTogglePostLike } from '@/hooks/api/post/useTogglePostLike';
+import { useTogglePostSave } from '@/hooks/api/post/useTogglePostSave';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useAppModalStore, useSimpleModalStore } from '@/stores/useModalStore';
+import { formatRelativeKorean } from '@/utils/date/formatDay';
+import { formatCountPlus, getDisplayName } from '@/utils/formatText';
+
+import * as S from './PostCardDesktop.styled';
+import MetaItem from '../MetaItem/MetaItem';
+import { PostCardProps } from '../PostCard';
+
+export default function PostCardDesktop({ post, isEdit = false, isSelected = false, onToggleSelect }: PostCardProps) {
+  const router = useRouter();
+  const { open: openAppModal } = useAppModalStore();
+  const { open: openSimpleModal } = useSimpleModalStore();
+  const isAuth = useAuthStore((s) => s.isAuth());
+
+  const {
+    postId,
+    title,
+    thumbnailUrl,
+    category,
+    author,
+    myStatus,
+    viewCount: viewCountProp,
+    likeCount: likeCountProp,
+    commentCount,
+    saveCount: saveCountProp,
+    createdAt,
+  } = post;
+
+  const categoryMeta = POST_CATEGORY_META[category.name as PostCategory];
+
+  const isLiked = Boolean(myStatus?.isLiked);
+  const isSaved = Boolean(myStatus?.isSaved);
+  const likeCount = likeCountProp ?? 0;
+  const saveCount = saveCountProp ?? 0;
+
+  const togglePostLikeMutation = useTogglePostLike();
+  const togglePostSaveMutation = useTogglePostSave();
+
+  const handleCardClick = () => {
+    if (isAuth) {
+      router.push(`/community/post/${postId}`);
+      return;
+    }
+    openAppModal('login');
+  };
+
+  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  const handleProfile = (e: React.SyntheticEvent) => {
+    stop(e);
+    if (author?.authorId && !author.isAnonymous) {
+      openSimpleModal('userProfile', { memberId: String(author.authorId) });
+    }
+  };
+
+  const onToggleLike = () => {
+    if (togglePostLikeMutation.isPending) return;
+    togglePostLikeMutation.mutate({ postId: String(postId), isLiked });
+  };
+
+  const onToggleSave = () => {
+    if (togglePostSaveMutation.isPending) return;
+    togglePostSaveMutation.mutate({ postId: String(postId), isSaved });
+  };
+
+  return (
+    <S.PostCardDesktop onClick={handleCardClick}>
+      {isEdit && (
+        <Checkbox
+          isChecked={!!isSelected}
+          onToggle={(checked) => onToggleSelect?.(checked)}
+          size='sm'
+          interactionVariant='normal'
+        />
+      )}
+
+      <S.CardContainer>
+        <S.ThumbnailWrapper>
+          <Thumbnail
+            ratio='16_10'
+            src={thumbnailUrl || DEFAULT_THUMBNAIL}
+            radius
+          />
+        </S.ThumbnailWrapper>
+
+        <S.Body>
+          <S.Main>
+            <S.MainHeader>
+              <S.Title>{title}</S.Title>
+              {author && (
+                <S.UserProfile onClick={handleProfile}>
+                  <AvatarPerson
+                    type='icon'
+                    size='xsm'
+                    src={author.profileUrl || undefined}
+                  />
+                  <S.Nickname>{getDisplayName(author.displayName, author.isAnonymous)}</S.Nickname>
+                </S.UserProfile>
+              )}
+            </S.MainHeader>
+
+            <S.MetaRow>
+              <MetaItem
+                count={likeCount}
+                icon={<Heart />}
+                fillIcon={<HeartFill />}
+                isActive={isLiked}
+                onClick={onToggleLike}
+                disabled={togglePostLikeMutation.isPending}
+              />
+              <MetaItem
+                count={commentCount || 0}
+                icon={<Comment />}
+                fillIcon={<CommentFill />}
+                isActive={false}
+              />
+              <MetaItem
+                count={saveCount}
+                icon={<Bookmark />}
+                fillIcon={<BookmarkFill />}
+                isActive={isSaved}
+                onClick={onToggleSave}
+                disabled={togglePostSaveMutation.isPending}
+              />
+            </S.MetaRow>
+          </S.Main>
+
+          <S.Aside onClick={stop}>
+            {categoryMeta && (
+              <SolidTag
+                label={categoryMeta.label}
+                color={categoryMeta.color}
+              />
+            )}
+            <S.SideMeta>
+              <S.MetaText>조회수 {formatCountPlus(viewCountProp || 0)}</S.MetaText>
+              <S.MetaText>{formatRelativeKorean(createdAt)}</S.MetaText>
+            </S.SideMeta>
+          </S.Aside>
+        </S.Body>
+      </S.CardContainer>
+    </S.PostCardDesktop>
+  );
+}

--- a/src/components/organisms/PostCard/PostCardMobile/PostCardMobile.tsx
+++ b/src/components/organisms/PostCard/PostCardMobile/PostCardMobile.tsx
@@ -17,26 +17,14 @@ import { useTogglePostLike } from '@/hooks/api/post/useTogglePostLike';
 import { useTogglePostSave } from '@/hooks/api/post/useTogglePostSave';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppModalStore } from '@/stores/useModalStore';
-import type { Post } from '@/types/post';
 import { formatRelativeKorean } from '@/utils/date/formatDay';
 import { formatCountPlus } from '@/utils/formatText';
 
 import * as S from './PostCardMobile.styled';
 import MetaItem from '../MetaItem/MetaItem';
+import { PostCardProps } from '../PostCard';
 
-interface PostCardMobileProps {
-  post: Post;
-  isEdit?: boolean;
-  isSelected?: boolean;
-  onToggleSelect?: (checked: boolean) => void;
-}
-
-export default function PostCardMobile({
-  post,
-  isEdit = false,
-  isSelected = false,
-  onToggleSelect,
-}: PostCardMobileProps) {
+export default function PostCardMobile({ post, isEdit = false, isSelected = false, onToggleSelect }: PostCardProps) {
   const { open: openAppModal } = useAppModalStore();
   const isAuth = useAuthStore((s) => s.isAuth());
   const router = useRouter();


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #515 

## 📋 작업 내용

- PostCard 반응형 래퍼 도입(Desktop/Mobile 분기)

기존의 PostCard를 PostCardDesktop으로 바꾸고 PostCard에서 미디어쿼리(max-width)로 분기했습니다!
```js
export default function PostCard(props: PostCardProps) {
  return (
    <>
      <S.DesktopOnly>
        <PostCardDesktop {...props} />
      </S.DesktopOnly>
      <S.MobileOnly>
        <PostCardMobile {...props} />
      </S.MobileOnly>
    </>
  );
}
```

서치 필터가 반응형이 안되어서 썸네일이 일정너비 이상 작아지지 않는데 해당 문제는 서치필터 반응형이 완료되면 해결될 듯 합니다!
https://github.com/user-attachments/assets/e263e9e4-4406-434e-b290-25cd7942f264


커뮤니티쪽 보시면 잘 줄어드는 것을 확인하실 수 있습니당!
https://github.com/user-attachments/assets/abf60f2c-2608-48ad-9d93-36bd1f387283



## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
