### PR TITLE
[FIX] searchfilter date params #513

### DIFF
--- a/src/app/(shared)/(standard)/mypage/community/comments/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/comments/page.tsx
@@ -15,7 +15,6 @@ import useGetUserComment from '@/hooks/api/member/useGetUserComment';
 import useScroll from '@/hooks/useScroll';
 import { useUrlSearchParams } from '@/hooks/useUrlSearchParams';
 import { SortType } from '@/types/member';
-import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 import * as S from './page.styled';
 
@@ -28,8 +27,8 @@ export default function Comments() {
     sort,
     categoryId: getSearchParamAsArray('categoryId').map(Number) || undefined,
     keyword: getSearchParam('keyword') ?? '',
-    startDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('startDate')),
-    endDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('endDate')),
+    startDate: getSearchParamAsDate('startDate') ?? undefined,
+    endDate: getSearchParamAsDate('endDate') ?? undefined,
   });
 
   const total = data?.pages?.[0]?.totalElements;

--- a/src/app/(shared)/(standard)/mypage/community/likes/comments/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/likes/comments/page.tsx
@@ -16,7 +16,6 @@ import useGetUserLikeComment from '@/hooks/api/member/useGetUserLikeComment';
 import useScroll from '@/hooks/useScroll';
 import { useUrlSearchParams } from '@/hooks/useUrlSearchParams';
 import { SortType } from '@/types/member';
-import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 import * as S from './page.styled';
 
@@ -29,8 +28,8 @@ export default function LikesComments() {
     sort,
     categoryId: getSearchParamAsArray('categoryId').map(Number) || undefined,
     keyword: getSearchParam('keyword') ?? '',
-    startDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('startDate')),
-    endDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('endDate')),
+    startDate: getSearchParamAsDate('startDate') ?? undefined,
+    endDate: getSearchParamAsDate('endDate') ?? undefined,
   });
 
   const total = data?.pages?.[0]?.totalElements;

--- a/src/app/(shared)/(standard)/mypage/community/likes/posts/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/likes/posts/page.tsx
@@ -16,7 +16,6 @@ import useGetUserLikePost from '@/hooks/api/member/useGetUserLikePost';
 import useScroll from '@/hooks/useScroll';
 import { useUrlSearchParams } from '@/hooks/useUrlSearchParams';
 import { SortType } from '@/types/member';
-import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 import * as S from './page.styled';
 
@@ -29,8 +28,8 @@ export default function LikesPosts() {
     sort,
     categoryId: getSearchParamAsArray('categoryId').map(Number) || undefined,
     keyword: getSearchParam('keyword') ?? '',
-    startDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('startDate')),
-    endDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('endDate')),
+    startDate: getSearchParamAsDate('startDate') ?? undefined,
+    endDate: getSearchParamAsDate('endDate') ?? undefined,
   });
 
   const total = data?.pages?.[0]?.totalElements;

--- a/src/app/(shared)/(standard)/mypage/community/posts/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/posts/page.tsx
@@ -19,7 +19,6 @@ import useScroll from '@/hooks/useScroll';
 import { useUrlSearchParams } from '@/hooks/useUrlSearchParams';
 import { useAlertModalStore } from '@/stores/useModalStore';
 import { SortType } from '@/types/member';
-import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 import * as S from './page.styled';
 
@@ -37,8 +36,8 @@ export default function Posts() {
     sort,
     categoryId: getSearchParamAsArray('categoryId').map(Number) || undefined,
     keyword: getSearchParam('keyword') ?? '',
-    startDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('startDate')),
-    endDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('endDate')),
+    startDate: getSearchParamAsDate('startDate') ?? undefined,
+    endDate: getSearchParamAsDate('endDate') ?? undefined,
   });
 
   const total = data?.pages?.[0]?.totalElements;

--- a/src/app/(shared)/(standard)/mypage/community/saves/page.tsx
+++ b/src/app/(shared)/(standard)/mypage/community/saves/page.tsx
@@ -15,7 +15,6 @@ import useGetUserSave from '@/hooks/api/member/useGetUserSave';
 import useScroll from '@/hooks/useScroll';
 import { useUrlSearchParams } from '@/hooks/useUrlSearchParams';
 import { SortType } from '@/types/member';
-import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 import * as S from './page.styled';
 
@@ -28,9 +27,9 @@ export default function Saves() {
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useGetUserSave({
     sort,
     categoryId: getSearchParamAsArray('categoryId').map(Number) || undefined,
-    keyword: getSearchParam('keyword') || undefined,
-    startDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('startDate')) || undefined,
-    endDate: formatDayAsDashYYYYMMDD(getSearchParamAsDate('endDate')) || undefined,
+    keyword: getSearchParam('keyword') ?? '',
+    startDate: getSearchParamAsDate('startDate') ?? undefined,
+    endDate: getSearchParamAsDate('endDate') ?? undefined,
   });
 
   const total = data?.pages[0].totalElements;

--- a/src/hooks/useUrlSearchParams.ts
+++ b/src/hooks/useUrlSearchParams.ts
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback } from 'react';
+import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 export const useUrlSearchParams = () => {
   const router = useRouter();
@@ -24,7 +25,8 @@ export const useUrlSearchParams = () => {
             }
           });
         } else if (value instanceof Date) {
-          newSearchParams.set(key, value.toISOString());
+          const formattedDate = formatDayAsDashYYYYMMDD(value);
+          newSearchParams.set(key, formattedDate || value.toISOString());
         } else {
           newSearchParams.set(key, String(value));
         }
@@ -54,9 +56,14 @@ export const useUrlSearchParams = () => {
   );
 
   const getSearchParamAsDate = useCallback(
-    (key: string): Date | null => {
+    (key: string): string | null => {
       const value = searchParams?.get(key);
-      return value ? new Date(value) : null;
+      if (!value) return null;
+
+      const date = new Date(value);
+      const formattedDate = formatDayAsDashYYYYMMDD(date);
+
+      return formattedDate ? formattedDate : null;
     },
     [searchParams],
   );

--- a/src/hooks/useUrlSearchParams.ts
+++ b/src/hooks/useUrlSearchParams.ts
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback } from 'react';
+
 import { formatDayAsDashYYYYMMDD } from '@/utils/date/formatDay';
 
 export const useUrlSearchParams = () => {


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #513 

## 📋 작업 내용

- date params 을 저희 데이터 전송 형식에 맞게 수정했습니다. 이제 2025.09.24T01030Z 이런 긴 문자로 안될겁니당


https://github.com/user-attachments/assets/edb6e8a3-19f6-495b-b074-161b91379f95




## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
