### PR TITLE
[FIX] 에디터 아이콘 사이즈 버그 #528

### DIFF
--- a/src/components/organisms/Editor/CustomToolbar/CustomToolbar.styled.ts
+++ b/src/components/organisms/Editor/CustomToolbar/CustomToolbar.styled.ts
@@ -105,13 +105,13 @@ export const DropdownButton = styled.button<ButtonProps>`
 
   cursor: pointer;
   transition: all 0.2s ease;
+`;
 
-  svg {
-    width: 2rem;
-    height: 2rem;
-    transition: transform 0.2s ease;
-    transform: ${({ isActive }) => (isActive ? 'rotate(180deg)' : 'rotate(0deg)')};
-  }
+export const DropdownIcon = styled.div<ButtonProps>`
+  width: 2rem;
+  height: 2rem;
+  transition: transform 0.2s ease;
+  transform: ${({ isActive }) => (isActive ? 'rotate(180deg)' : 'rotate(0deg)')};
 `;
 
 export const MediaIcon = styled.div`

--- a/src/components/organisms/Editor/CustomToolbar/Sections/CustomToolbarPalette.tsx
+++ b/src/components/organisms/Editor/CustomToolbar/Sections/CustomToolbarPalette.tsx
@@ -82,7 +82,10 @@ export default function CustomToolbarPalette({
           onClick={() => togglePopup('typography')}
           isActive={activePopup === 'typography'}
         >
-          본문 <ChevronDown />
+          본문
+          <S.DropdownIcon isActive={activePopup === 'typography'}>
+            <ChevronDown />
+          </S.DropdownIcon>
         </S.DropdownButton>
         {activePopup === 'typography' && (
           <PopupWrapper onClose={closePopups}>
@@ -103,7 +106,10 @@ export default function CustomToolbarPalette({
           onClick={() => togglePopup('font')}
           isActive={activePopup === 'font'}
         >
-          {selectedFont} <ChevronDown />
+          {selectedFont}{' '}
+          <S.DropdownIcon isActive={activePopup === 'font'}>
+            <ChevronDown />
+          </S.DropdownIcon>
         </S.DropdownButton>
         {activePopup === 'font' && (
           <PopupWrapper onClose={closePopups}>
@@ -127,8 +133,9 @@ export default function CustomToolbarPalette({
         >
           <S.ColorButtonContent>
             {currentColor ? <S.ColorIndicator color={currentColor} /> : '색상'}
-
-            <ChevronDown />
+            <S.DropdownIcon isActive={activePopup === 'color'}>
+              <ChevronDown />
+            </S.DropdownIcon>
           </S.ColorButtonContent>
         </S.DropdownButton>
         {activePopup === 'color' && (


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #528 

## 📋 작업 내용

SVG 아이콘 스타일링 시,

```js
svg {
    width: 2rem;
    height: 2rem;
    transition: transform 0.2s ease;
    transform: ${({ isActive }) => (isActive ? 'rotate(180deg)' : 'rotate(0deg)')};
  }
 ```
이런식으로 직접 svg 태그에 스타일을 주는 방식 대신

```js
export const DropdownIcon = styled.div<ButtonProps>`
  width: 2rem;
  height: 2rem;
  transition: transform 0.2s ease;
  transform: ${({ isActive }) => (isActive ? 'rotate(180deg)' : 'rotate(0deg)')};
`;
```

이런식으로 부모 div를 만들고 거기에 width, height를 주는 방식으로 사이즈를 설정해주세요!
-> ios 아이콘 이슈 해결하면서 svg 파일에 전체적으로 width: 100%, height: 100% 가 들어가게 되어서 그렇습니다!


## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
