### PR TITLE
[FIX] 마이페이지 qa 이슈 해결 #533

### DIFF
--- a/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.styled.ts
@@ -67,21 +67,6 @@ export const CommentRight = styled.div`
   }
 `;
 
-export const Post = styled.div`
-  display: flex;
-  align-items: center;
-
-  gap: 0.8rem;
-  color: ${({ theme }) => theme.semantic.label.alternative};
-`;
-
-export const PostIcon = styled.div`
-  width: 1.8rem;
-  height: 1.8rem;
-
-  color: ${({ theme }) => theme.semantic.label.alternative};
-`;
-
 export const PostTitle = styled.p`
   width: 25rem;
 

--- a/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.tsx
+++ b/src/app/(shared)/(standard)/mypage/_components/CommentListRow/CommentListRow.tsx
@@ -31,12 +31,7 @@ export default function CommentListRow({ commentData }: CommentListRowProps) {
       </S.CommentLeft>
 
       <S.CommentRight>
-        <S.Post>
-          <S.PostIcon>
-            <ArrowTurnDownRight />
-          </S.PostIcon>
-          <S.PostTitle>{post.title}</S.PostTitle>
-        </S.Post>
+        <S.PostTitle>{post.title}</S.PostTitle>
         <S.CommentCreatedAt>{formatDayAsSlashYYMMDD(createdAt)}</S.CommentCreatedAt>
       </S.CommentRight>
     </S.CommentListRow>

--- a/src/app/(shared)/(standard)/mypage/community/posts/page.styled.ts
+++ b/src/app/(shared)/(standard)/mypage/community/posts/page.styled.ts
@@ -20,7 +20,6 @@ export const FilterHeader = styled.div`
 
 export const ListControlsWrapper = styled.div`
   display: flex;
-  flex-direction: row-reverse;
   justify-content: space-between;
 
   width: 100%;


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #533 

## 📋 작업 내용

- 마이 > 커뮤니티 [선택]버튼이 왼쪽, 최신순 정렬 필터 오른쪽
<img width="625" height="143" alt="스크린샷 2025-09-27 오전 2 47 28" src="https://github.com/user-attachments/assets/7241f8c2-45b4-4940-ab07-6982e049d946" />

- 마이 > 댓글 카드에 원글 화살표 없애기
<img width="593" height="141" alt="스크린샷 2025-09-27 오전 2 47 13" src="https://github.com/user-attachments/assets/1addbe5c-0795-49da-8ad4-9ddf5ba356a5" />

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
