### PR TITLE
[FIX] PostCard 회원/비회원 처리 수정 #547

### DIFF
--- a/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
+++ b/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
@@ -12,7 +12,7 @@ import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
 import Checkbox from '@/components/atoms/Checkbox/Checkbox';
 import SolidTag from '@/components/atoms/SolidTag/SolidTag';
 import Thumbnail from '@/components/atoms/Thumbnail/Thumbnail';
-import { POST_CATEGORY_META, PostCategory } from '@/constants/common';
+import { POST_CATEGORY_LABELS, POST_CATEGORY_META, PostCategory } from '@/constants/common';
 import { DEFAULT_THUMBNAIL } from '@/constants/image';
 import { useTogglePostLike } from '@/hooks/api/post/useTogglePostLike';
 import { useTogglePostSave } from '@/hooks/api/post/useTogglePostSave';
@@ -56,7 +56,7 @@ export default function PostCardDesktop({ post, isEdit = false, isSelected = fal
   const togglePostSaveMutation = useTogglePostSave();
 
   const handleCardClick = () => {
-    if (isAuth) {
+    if (category.name === POST_CATEGORY_LABELS.REFLECTION || isAuth) {
       router.push(`/community/post/${postId}`);
       return;
     }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #547 

## 📋 작업 내용

- 게시글 카드에서 상세페이지로 이동 조건을 "카테고리가 사색/고민"이거나 "회원"이거나 로 수정하였습니다

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
