### PR TITLE
[FIX] 댓글 입력 시 IME 조합/키 반복으로 인한 중복 submit 방지 #551

### DIFF
--- a/src/components/molecules/CommentField/CommentField.tsx
+++ b/src/components/molecules/CommentField/CommentField.tsx
@@ -110,6 +110,8 @@ export default function CommentField({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.nativeEvent?.isComposing) return;
+        if (e.repeat) return;
         e.preventDefault();
         if (!isSubmitDisabled) {
           handleSubmit();


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #551 

## 📋 작업 내용

- 한글 IME 중복 입력, 키 꾹 눌렀을 때 중복 이벤트 차단

=> 한글/일본어 같은 IME 입력 중에는 Enter 키 이벤트가 여러 번 발생해서 한글 입력 중 엔터를 하면 중복 이벤트가 발생하여 API 2번 호출 된다고 합니다!
=> 추가해서 키를 꾹 눌렀을때 api 요청이 여러번 가는 것도 막아뒀습니다!

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
