### PR TITLE
[FIX] 익명 처리, 댓글 입력란 반응형 수정 #556

### DIFF
--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostAuthor/PostAuthor.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostAuthor/PostAuthor.tsx
@@ -98,7 +98,7 @@ export default function PostAuthor({ author, postId, isMine = false, isAdmin = f
           size='md'
           src={author?.profileUrl || undefined}
         />
-        <S.PostUserName>{getDisplayName(author?.displayName || '', author?.isAnonymous || false)}</S.PostUserName>
+        <S.PostUserName>{getDisplayName(author?.displayName || null, author?.isAnonymous || false)}</S.PostUserName>
       </S.AuthorInfo>
 
       {shouldShowMenu && (

--- a/src/components/molecules/CommentField/CommentField.styled.ts
+++ b/src/components/molecules/CommentField/CommentField.styled.ts
@@ -21,9 +21,10 @@ export const Wrapper = styled.div`
 `;
 
 export const TextareaContainer = styled.div`
-  width: 100%;
-  height: 10rem;
   position: relative;
+
+  width: 100%;
+  height: 100%;
 `;
 
 export const Textarea = styled.textarea`
@@ -46,11 +47,10 @@ export const BottomSection = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: auto;
 
   ${mqMax.tablet} {
     flex-direction: column;
-    align-items: end;
+    align-items: flex-end;
     gap: 1rem;
   }
 `;


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #556 

## 📋 작업 내용

- 상세조회 페이지 익명 표시 X 수정 -> null 처리
<img width="1444" height="404" alt="image" src="https://github.com/user-attachments/assets/81272a52-0f51-41ab-a4c4-96f0865d4b30" />

- 크롬에서는 안깨지는데 사파리에서는 레이아웃이 깨져서 수정하였습니다!
<img width="176" height="120" alt="스크린샷 2025-10-05 오전 11 14 50" src="https://github.com/user-attachments/assets/1276d706-b4eb-4119-9ffd-59795b64178e" />

textarea에 고정 높이가 들어가있다보니 크롬에서는 자동으로 오버플로우 안되게 밀어주는데 사파리에서는 안밀어주나봐요 그래서 고정 높이 없앴습니다!

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
