### PR TITLE
[FEAT] 비회원 접근 시 로그인 모달 노출 기능 추가 #564

### DIFF
--- a/src/app/(shared)/(standard)/community/_components/CommunityActions.tsx
+++ b/src/app/(shared)/(standard)/community/_components/CommunityActions.tsx
@@ -4,7 +4,8 @@ import { useRouter } from 'next/navigation';
 
 import OutlinedButton from '@/components/atoms/OutlinedButton/OutlinedButton';
 import useGetDailyQuestionsQuery from '@/hooks/api/daily/useGetDailyQuestions';
-import { useAlertModalStore } from '@/stores/useModalStore';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useAlertModalStore, useAppModalStore } from '@/stores/useModalStore';
 
 import * as S from './CommunityActions.styled';
 
@@ -12,8 +13,15 @@ export default function CommunityActions() {
   const router = useRouter();
   const { data } = useGetDailyQuestionsQuery();
   const { open } = useAlertModalStore();
+  const { open: openAppModal } = useAppModalStore();
+  const isAuth = useAuthStore((s) => s.isAuth());
 
-  const onClick = () => {
+  const onClickDaily = () => {
+    if (!isAuth) {
+      openAppModal('login');
+      return;
+    }
+
     if (data?.answer) {
       router.push('/community/write?type=daily');
       return;
@@ -29,6 +37,15 @@ export default function CommunityActions() {
     });
   };
 
+  const onClickWrite = () => {
+    if (!isAuth) {
+      openAppModal('login');
+      return;
+    }
+
+    router.push('/community/write?type=post');
+  };
+
   return (
     <S.Container>
       <OutlinedButton
@@ -36,7 +53,7 @@ export default function CommunityActions() {
         size='sm'
         color='primary'
         interactionVariant='normal'
-        onClick={onClick}
+        onClick={onClickDaily}
       />
 
       <OutlinedButton
@@ -44,7 +61,7 @@ export default function CommunityActions() {
         size='sm'
         color='primary'
         interactionVariant='normal'
-        onClick={() => router.push('/community/write?type=post')}
+        onClick={onClickWrite}
       />
     </S.Container>
   );

--- a/src/app/(shared)/(standard)/community/post/[id]/_components/PostLikesSaved/PostLikesSaved.tsx
+++ b/src/app/(shared)/(standard)/community/post/[id]/_components/PostLikesSaved/PostLikesSaved.tsx
@@ -3,6 +3,8 @@ import HeartIcon from '@/assets/icons/heart.svg';
 import IconButton from '@/components/atoms/IconButton/IconButton';
 import { useTogglePostLike } from '@/hooks/api/post/useTogglePostLike';
 import { useTogglePostSave } from '@/hooks/api/post/useTogglePostSave';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useAppModalStore } from '@/stores/useModalStore';
 import { formatCountPlus } from '@/utils/formatText';
 
 import * as S from './PostLikesSaved.styled';
@@ -24,13 +26,23 @@ export default function PostLikesSaved({
 }: PostLikesSavedProps) {
   const togglePostLikeMutation = useTogglePostLike();
   const togglePostSaveMutation = useTogglePostSave();
+  const { open } = useAppModalStore();
+  const isAuth = useAuthStore((s) => s.isAuth());
 
   const handleLikeClick = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostLikeMutation.isPending) return;
     togglePostLikeMutation.mutate({ postId, isLiked });
   };
 
   const handleSaveClick = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostSaveMutation.isPending) return;
     togglePostSaveMutation.mutate({ postId, isSaved });
   };

--- a/src/components/molecules/CommentField/CommentField.tsx
+++ b/src/components/molecules/CommentField/CommentField.tsx
@@ -6,6 +6,8 @@ import Checkbox from '@/components/atoms/Checkbox/Checkbox';
 import SolidButton from '@/components/atoms/SolidButton/SolidButton';
 import { useCreateComment } from '@/hooks/api/comment/useCreateComment';
 import { useUpdateComment } from '@/hooks/api/comment/useUpdateComment';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { useAppModalStore } from '@/stores/useModalStore';
 
 import * as S from './CommentField.styled';
 
@@ -45,6 +47,8 @@ export default function CommentField({
   const [localIsAnonymous, setLocalIsAnonymous] = useState(false);
   const { createComment, isLoading: createLoading } = useCreateComment(postId);
   const updateCommentMutation = useUpdateComment();
+  const { open } = useAppModalStore();
+  const isAuth = useAuthStore((s) => s.isAuth());
 
   const handleContentChange = useCallback(
     (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -58,6 +62,11 @@ export default function CommentField({
 
   const handleSubmit = useCallback(() => {
     if (content.trim()) {
+      if (!isAuth) {
+        open('login');
+        return;
+      }
+
       if (isEdit && commentId) {
         updateCommentMutation.mutate(
           {

--- a/src/components/organisms/Modal/UserProfile/UserProfileModal.tsx
+++ b/src/components/organisms/Modal/UserProfile/UserProfileModal.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 
 import { HTTPError } from '@/api/axios/errors/HTTPError';
 import AvatarPerson from '@/components/atoms/AvatarPerson/AvatarPerson';
-import Loading from '@/components/organisms/Loading/Loading';
 import useGetUserProfile from '@/hooks/api/member/useGetUserProfile';
 import { useAlertModalStore } from '@/stores/useModalStore';
 
@@ -27,15 +26,7 @@ export default function UserProfileModal({ memberId }: UserProfileModalProps) {
     }
   }, [error, openAlert]);
 
-  if (isLoading) {
-    return (
-      <S.UserProfileModalContainer>
-        <Loading />
-      </S.UserProfileModalContainer>
-    );
-  }
-
-  if (!profile) return;
+  if (isLoading || !profile) return;
 
   return (
     <S.UserProfileModalContainer>

--- a/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
+++ b/src/components/organisms/PostCard/PostCardDesktop/PostCardDesktop.tsx
@@ -73,11 +73,19 @@ export default function PostCardDesktop({ post, isEdit = false, isSelected = fal
   };
 
   const onToggleLike = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostLikeMutation.isPending) return;
     togglePostLikeMutation.mutate({ postId: String(postId), isLiked });
   };
 
   const onToggleSave = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostSaveMutation.isPending) return;
     togglePostSaveMutation.mutate({ postId: String(postId), isSaved });
   };

--- a/src/components/organisms/PostCard/PostCardMobile/PostCardMobile.tsx
+++ b/src/components/organisms/PostCard/PostCardMobile/PostCardMobile.tsx
@@ -61,11 +61,19 @@ export default function PostCardMobile({ post, isEdit = false, isSelected = fals
   };
 
   const onToggleLike = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostLikeMutation.isPending) return;
     togglePostLikeMutation.mutate({ postId: String(postId), isLiked });
   };
 
   const onToggleSave = () => {
+    if (!isAuth) {
+      open('login');
+      return;
+    }
     if (togglePostSaveMutation.isPending) return;
     togglePostSaveMutation.mutate({ postId: String(postId), isSaved });
   };

--- a/src/hooks/api/member/useGetUserProfile.ts
+++ b/src/hooks/api/member/useGetUserProfile.ts
@@ -2,14 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { memberApi } from '@/api/memberApis';
 import { MEMBER_QUERY_KEYS } from '@/constants/queryKeys';
-import { useAuthStore } from '@/stores/useAuthStore';
 
 export default function useGetUserProfile(memberId: string) {
-  const isAuth = useAuthStore((s) => s.isAuth());
-
   return useQuery({
     queryKey: [...MEMBER_QUERY_KEYS.PROFILE, memberId],
     queryFn: () => memberApi.getUserProfile(memberId),
-    enabled: !!memberId && isAuth,
+    enabled: !!memberId,
   });
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #564 

## 📋 작업 내용

- 비회원일때 게시글 카드에서 좋아요, 저장 시 로그인 모달 노출
- 비회원일때 게시글 상세조회에서 좋아요, 저장, 댓글 입력 시 로그인 모달 노출
- 비회원일때 게시글 작성 버튼 누를 시 로그인 모달 노출

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
