### PR TITLE
[FIX] 에디터 색상 선택 시 null 값으로 인한 오류 수정 #566

### DIFF
--- a/src/components/organisms/Editor/CustomToolbar/Sections/CustomToolbarPalette.tsx
+++ b/src/components/organisms/Editor/CustomToolbar/Sections/CustomToolbarPalette.tsx
@@ -155,7 +155,7 @@ export default function CustomToolbarPalette({
             <ColorPopup
               editor={editor}
               onClose={closePopups}
-              currentColor={currentColor}
+              currentColor={currentColor ?? '#000000'}
             />
           </PopupWrapper>
         )}


### PR DESCRIPTION
## ⭐️ 관련 이슈

- Closes #566 

## 📋 작업 내용

- 에디터에서 색상 선택 시 currentColor가 null로 전달되어 발생하던 toUpperCase 관련 오류를 수정했습니다.
- editor.getAttributes('textStyle').color 값을 가져올 때  null일 경우 '#000000' 기본값으로 처리

## 🛠️ 특이 사항

## ⚡️ 리뷰 요구사항 (선택)
